### PR TITLE
Issue #2332 - Add TOC extension to the markdown render

### DIFF
--- a/taiga/mdrender/service.py
+++ b/taiga/mdrender/service.py
@@ -77,6 +77,7 @@ def _make_extensions_list(project=None):
             "extra",
             "codehilite",
             "sane_lists",
+            "toc",
             "nl2br"]
 
 


### PR DESCRIPTION
Try this in wiki pages:

```
[TOC]

Lorem ipsum dolor sit amet
==========================
Consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

Aut harum
---------
Debitis culpa vero sit, assumenda cupiditate voluptatem vel numquam nulla, laudantium eligendi commodi accusantium natus exercitationem obcaecati minus quibusdam illo voluptate ab.

### Ab adipisci
Nulla ipsam quia.

Iure nesciunt doloribus incidunt numquam voluptate magni, ratione reiciendis laudantium atque est, reiciendis fugiat laborum dolore, amet modi laborum sapiente corrupti omnis porro neque repudiandae error voluptate quod? Hic beatae possimus repudiandae error iusto similique natus, earum eos ab at dolore ratione, sint vel sapiente ad eos eaque, maiores magnam aliquam.

Tempora harum ipsum
-------------------
Dolor saepe at, quo a odio error, magni unde harum, fugit sit nulla illum expedita praesentium vel maxime, laborum modi et sint eos nisi odio suscipit. Id enim fuga ex assumenda praesentium excepturi molestias incidunt, at ad facilis veritatis possimus, ipsa et animi perferendis incidunt ab deleniti vel, vitae repudiandae doloribus recusandae eveniet reiciendis labore quidem consectetur quasi minus. Voluptates quam hic eum perspiciatis?
```