### PR TITLE
Uncomment the DATABASES dict in settings/local.py.example, and add a...

### DIFF
--- a/settings/local.py.example
+++ b/settings/local.py.example
@@ -16,17 +16,17 @@
 
 from .development import *
 
-#DATABASES = {
-#    'default': {
-#        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
-#        'NAME': 'taiga',
-#        'USER': 'taiga',
-#        'PASSWORD': '',
-#        'HOST': '',
-#        'PORT': '',
-#    }
-#}
-#
+DATABASES = {
+    'default': {
+        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
+        'NAME': 'taiga',
+        'USER': 'taiga',
+        'PASSWORD': 'changeme',
+        'HOST': '',
+        'PORT': '',
+    }
+}
+
 #HOST="http://taiga.projects.kaleidos.net"
 #
 #MEDIA_ROOT = '/home/taiga/media'


### PR DESCRIPTION
default PASSWORD value to it, in order to account for the addition of Postgresql authorization instructions to the setup-development docs (see https://github.com/taigaio/taiga-doc/issues/52)

This commit is required by https://github.com/taigaio/taiga-doc/pull/62