### PR TITLE
Fix a bug that create non-ouner memberships where the importer user is a member of the importer project

### DIFF
--- a/taiga/export_import/service.py
+++ b/taiga/export_import/service.py
@@ -155,7 +155,10 @@ def store_role(project, role):
 def store_roles(project, data):
     results = []
     for role in data.get("roles", []):
-        results.append(store_role(project, role))
+        serialized = store_role(project, role)
+        if serialized:
+            results.append(serialized)
+
     return results
 
 

--- a/tests/integration/test_importer_api.py
+++ b/tests/integration/test_importer_api.py
@@ -53,17 +53,17 @@ def test_valid_project_import_without_extra_data(client):
     data = {
         "name": "Imported project",
         "description": "Imported project",
+        "roles": [{"name": "Role"}]
     }
 
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 201
     response_data = json.loads(response.content.decode("utf-8"))
     must_empty_children = [
-        "issues", "user_stories", "roles", "us_statuses", "wiki_pages", "priorities",
+        "issues", "user_stories", "us_statuses", "wiki_pages", "priorities",
         "severities", "milestones", "points", "issue_types", "task_statuses",
-        "memberships", "issue_statuses", "wiki_links",
+        "issue_statuses", "wiki_links",
     ]
-
     assert all(map(lambda x: len(response_data[x]) == 0, must_empty_children))
     assert response_data["owner"] == user.email
 
@@ -166,6 +166,22 @@ def test_valid_project_import_with_extra_data(client):
     assert response_data["owner"] == user.email
 
 
+def test_invalid_project_import_without_roles(client):
+    user = f.UserFactory.create()
+    client.login(user)
+
+    url = reverse("importer-list")
+    data = {
+        "name": "Imported project",
+        "description": "Imported project",
+    }
+
+    response = client.post(url, json.dumps(data), content_type="application/json")
+    assert response.status_code == 400
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert len(response_data) == 2
+    assert Project.objects.filter(slug="imported-project").count() == 0
+
 def test_invalid_project_import_with_extra_data(client):
     user = f.UserFactory.create()
     client.login(user)
@@ -174,7 +190,10 @@ def test_invalid_project_import_with_extra_data(client):
     data = {
         "name": "Imported project",
         "description": "Imported project",
-        "roles": [{}],
+        "roles": [{
+            "permissions": [],
+            "name": "Test"
+        }],
         "us_statuses": [{}],
         "severities": [{}],
         "priorities": [{}],
@@ -187,7 +206,7 @@ def test_invalid_project_import_with_extra_data(client):
     response = client.post(url, json.dumps(data), content_type="application/json")
     assert response.status_code == 400
     response_data = json.loads(response.content.decode("utf-8"))
-    assert len(response_data) == 8
+    assert len(response_data) == 7
     assert Project.objects.filter(slug="imported-project").count() == 0
 
 
@@ -198,6 +217,10 @@ def test_valid_project_import_with_custom_attributes(client):
     data = {
         "name": "Imported project",
         "description": "Imported project",
+        "roles": [{
+            "permissions": [],
+            "name": "Test"
+        }],
         "userstorycustomattributes": [{
             "name": "custom attribute example 1",
             "description": "short description 1",
@@ -234,6 +257,10 @@ def test_invalid_project_import_with_custom_attributes(client):
     data = {
         "name": "Imported project",
         "description": "Imported project",
+        "roles": [{
+            "permissions": [],
+            "name": "Test"
+        }],
         "userstorycustomattributes": [{ }],
         "taskcustomattributes": [{ }],
         "issuecustomattributes": [{ }]


### PR DESCRIPTION
Explanation for @superalex :

OLD CODE:

```diff
         // Create all roles
         if "roles" in data:
             service.store_roles(project_serialized.object, data)
 
         // Create all memberships with is_owner=False
         if "memberships" in data:
             service.store_memberships(project_serialized.object, data)

         // If there is no memberships for the importer user
-        if project_serialized.object.memberships.filter(user=project_serialized.object.owner).count() == 0:
             // If there are roles
-            if project_serialized.object.roles.all().count() > 0:
                 // Create a membership with is_owner = True for the importer user
-                Membership.objects.create(
-                    project=project_serialized.object,
-                    email=project_serialized.object.owner.email,
-                    user=project_serialized.object.owner,
-                    role=project_serialized.object.roles.all().first(),
-                    is_owner=True
-                )
              // Problems:
              // - If the importer user is a member of the imported project: 
              //   is_owner == False ->>> So PETE_WITH TOMATOES at the next call to the api
              // - What's happen if the request has no roles?? ¿? The membership of
              //   importer user will never be created (or it will be created with is_owner=False if 
              //   is a member of the imported project).
```

NEW CODE

```diff
         // Create all roles
         if "roles" in data:
             service.store_roles(project_serialized.object, data)

         // Create all memberships with is_owner=False 
         if "memberships" in data:
             service.store_memberships(project_serialized.object, data)

           // If no roles ->>> PETE
+        if project_serialized.object.roles.all().count() > 0:
+            raise exc.BadRequest(_("We needed at least one role"))
+
+        try:
               // Get the membership of the importer user and set is_owner = True
+            owner_membership = project_serialized.object.memberships.get(user=project_serialized.object.owner)
+            owner_membership.is_owner = True
+            owner_membership.save()
+        except Membership.DoesNotExist:
               // Create the membership for importer user with is_owner = True
+            Membership.objects.create(
+                project=project_serialized.object,
+                email=project_serialized.object.owner.email,
+                user=project_serialized.object.owner,
+                role=project_serialized.object.roles.all().first(),
+                is_owner=True
+            )
```