### PR TITLE
Allow users to enter a ref number in the search

### DIFF
--- a/taiga/searches/services.py
+++ b/taiga/searches/services.py
@@ -24,6 +24,7 @@ MAX_RESULTS = getattr(settings, "SEARCHES_MAX_RESULTS", 150)
 def search_user_stories(project, text):
     model_cls = apps.get_model("userstories", "UserStory")
     where_clause = ("to_tsvector(coalesce(userstories_userstory.subject) || ' ' || "
+                    "coalesce(userstories_userstory.ref) || ' ' || "
                     "coalesce(userstories_userstory.description)) @@ plainto_tsquery(%s)")
 
     if text:
@@ -35,8 +36,9 @@ def search_user_stories(project, text):
 
 def search_tasks(project, text):
     model_cls = apps.get_model("tasks", "Task")
-    where_clause = ("to_tsvector(coalesce(tasks_task.subject, '') || ' ' || coalesce(tasks_task.description, '')) "
-                    "@@ plainto_tsquery(%s)")
+    where_clause = ("to_tsvector(coalesce(tasks_task.subject, '') || ' ' || "
+                    "coalesce(tasks_task.ref) || ' ' || "
+                    "coalesce(tasks_task.description, '')) @@ plainto_tsquery(%s)")
 
     if text:
         return (model_cls.objects.extra(where=[where_clause], params=[text])
@@ -47,8 +49,9 @@ def search_tasks(project, text):
 
 def search_issues(project, text):
     model_cls = apps.get_model("issues", "Issue")
-    where_clause = ("to_tsvector(coalesce(issues_issue.subject) || ' ' || coalesce(issues_issue.description)) "
-                    "@@ plainto_tsquery(%s)")
+    where_clause = ("to_tsvector(coalesce(issues_issue.subject) || ' ' || "
+                    "coalesce(issues_issue.ref) || ' ' || "
+                    "coalesce(issues_issue.description)) @@ plainto_tsquery(%s)")
 
     if text:
         return (model_cls.objects.extra(where=[where_clause], params=[text])


### PR DESCRIPTION
Simple change to add the Ref column in to the columns that are searched when the user searches in a project for matching user stories, tasks and issues.

I looked at updating the tests (taiga-back/tests/integration/test-searches.py), but wasn't too sure how to do this given the Ref is generated automatically when the test user stories, tasks, issues are generated. So would need a bit of advice if you'd like me to add a test for this...