### PR TITLE
Supporting a "field type" property for custom fields (taiga-front #451)

### DIFF
--- a/taiga/projects/custom_attributes/migrations/0006_add_customattribute_field_type.py
+++ b/taiga/projects/custom_attributes/migrations/0006_add_customattribute_field_type.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('custom_attributes', '0005_auto_20150505_1639'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='issuecustomattribute',
+            name='field_type',
+            field=models.CharField(default='TEXT', max_length=5, verbose_name='attribute field type'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='taskcustomattribute',
+            name='field_type',
+            field=models.CharField(default='TEXT', max_length=5, verbose_name='attribute field type'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='userstorycustomattribute',
+            name='field_type',
+            field=models.CharField(default='TEXT', max_length=5, verbose_name='attribute field type'),
+            preserve_default=True,
+        ),
+
+    ]

--- a/taiga/projects/custom_attributes/models.py
+++ b/taiga/projects/custom_attributes/models.py
@@ -35,7 +35,7 @@ class AbstractCustomAttribute(models.Model):
     )
     name = models.CharField(null=False, blank=False, max_length=64, verbose_name=_("name"))
     description = models.TextField(null=False, blank=True, verbose_name=_("description"))
-    field_type = models.CharField(null=False, blank=False, choices=FIELD_TYPES, max_length=5, verbose_name=_("type"))
+    field_type = models.CharField(null=False, blank=False, choices=FIELD_TYPES, max_length=5, default='TEXT', verbose_name=_("type"))
     order = models.IntegerField(null=False, blank=False, default=10000, verbose_name=_("order"))
     project = models.ForeignKey("projects.Project", null=False, blank=False, related_name="%(class)ss",
                                 verbose_name=_("project"))

--- a/taiga/projects/custom_attributes/models.py
+++ b/taiga/projects/custom_attributes/models.py
@@ -27,9 +27,15 @@ from taiga.projects.occ.mixins import OCCModelMixin
 #  Custom Attribute Models
 #######################################################
 
+
 class AbstractCustomAttribute(models.Model):
+    FIELD_TYPES = (
+        ('TEXT', 'Text'),
+        ('MULTI', 'Multi-Line Text')
+    )
     name = models.CharField(null=False, blank=False, max_length=64, verbose_name=_("name"))
     description = models.TextField(null=False, blank=True, verbose_name=_("description"))
+    field_type = models.CharField(null=False, blank=False, choices=FIELD_TYPES, max_length=5, verbose_name=_("type"))
     order = models.IntegerField(null=False, blank=False, default=10000, verbose_name=_("order"))
     project = models.ForeignKey("projects.Project", null=False, blank=False, related_name="%(class)ss",
                                 verbose_name=_("project"))


### PR DESCRIPTION
This is the taiga-back change required to support the work for taiga-front issue #451, to implement a multi-line text box custom field type.

