### PR TITLE
Fix import and deletion of projects

### DIFF
--- a/taiga/events/events.py
+++ b/taiga/events/events.py
@@ -53,6 +53,9 @@ def emit_event_for_model(obj, *, type:str="change", channel:str="events",
     Sends a model change event.
     """
 
+    if obj._importing:
+        return None
+
     assert type in set(["create", "change", "delete"])
     assert hasattr(obj, "project_id")
 

--- a/taiga/projects/issues/apps.py
+++ b/taiga/projects/issues/apps.py
@@ -23,25 +23,39 @@ from taiga.projects.custom_attributes import signals as custom_attributes_handle
 from . import signals as handlers
 
 
+def connect_issues_signals():
+    # Finished date
+    signals.pre_save.connect(handlers.set_finished_date_when_edit_issue,
+                             sender=apps.get_model("issues", "Issue"),
+                             dispatch_uid="set_finished_date_when_edit_issue")
+
+    # Tags
+    signals.pre_save.connect(generic_handlers.tags_normalization,
+                             sender=apps.get_model("issues", "Issue"),
+                             dispatch_uid="tags_normalization_issue")
+    signals.post_save.connect(generic_handlers.update_project_tags_when_create_or_edit_taggable_item,
+                              sender=apps.get_model("issues", "Issue"),
+                              dispatch_uid="update_project_tags_when_create_or_edit_taggable_item_issue")
+    signals.post_delete.connect(generic_handlers.update_project_tags_when_delete_taggable_item,
+                                sender=apps.get_model("issues", "Issue"),
+                                dispatch_uid="update_project_tags_when_delete_taggable_item_issue")
+
+    # Custom Attributes
+    signals.post_save.connect(custom_attributes_handlers.create_custom_attribute_value_when_create_issue,
+                              sender=apps.get_model("issues", "Issue"),
+                              dispatch_uid="create_custom_attribute_value_when_create_issue")
+
+def disconnect_issues_signals():
+    signals.pre_save.disconnect(dispatch_uid="set_finished_date_when_edit_issue")
+    signals.pre_save.disconnect(dispatch_uid="tags_normalization_issue")
+    signals.post_save.disconnect(dispatch_uid="update_project_tags_when_create_or_edit_taggable_item_issue")
+    signals.post_delete.disconnect(dispatch_uid="update_project_tags_when_delete_taggable_item_issue")
+    signals.post_save.disconnect(dispatch_uid="create_custom_attribute_value_when_create_issue")
+
+
 class IssuesAppConfig(AppConfig):
     name = "taiga.projects.issues"
     verbose_name = "Issues"
 
     def ready(self):
-        # Finished date
-        signals.pre_save.connect(handlers.set_finished_date_when_edit_issue,
-                                 sender=apps.get_model("issues", "Issue"),
-                                 dispatch_uid="set_finished_date_when_edit_issue")
-
-        # Tags
-        signals.pre_save.connect(generic_handlers.tags_normalization,
-                                 sender=apps.get_model("issues", "Issue"))
-        signals.post_save.connect(generic_handlers.update_project_tags_when_create_or_edit_taggable_item,
-                                  sender=apps.get_model("issues", "Issue"))
-        signals.post_delete.connect(generic_handlers.update_project_tags_when_delete_taggable_item,
-                                    sender=apps.get_model("issues", "Issue"))
-
-        # Custom Attributes
-        signals.post_save.connect(custom_attributes_handlers.create_custom_attribute_value_when_create_issue,
-                                  sender=apps.get_model("issues", "Issue"),
-                                  dispatch_uid="create_custom_attribute_value_when_create_issue")
+        connect_issues_signals()

--- a/taiga/projects/tasks/apps.py
+++ b/taiga/projects/tasks/apps.py
@@ -22,31 +22,49 @@ from taiga.projects import signals as generic_handlers
 from taiga.projects.custom_attributes import signals as custom_attributes_handlers
 from . import signals as handlers
 
+def connect_tasks_signals():
+    # Cached prev object version
+    signals.pre_save.connect(handlers.cached_prev_task,
+                             sender=apps.get_model("tasks", "Task"),
+                             dispatch_uid="cached_prev_task")
+
+    # Open/Close US and Milestone
+    signals.post_save.connect(handlers.try_to_close_or_open_us_and_milestone_when_create_or_edit_task,
+                              sender=apps.get_model("tasks", "Task"),
+                              dispatch_uid="try_to_close_or_open_us_and_milestone_when_create_or_edit_task")
+    signals.post_delete.connect(handlers.try_to_close_or_open_us_and_milestone_when_delete_task,
+                                sender=apps.get_model("tasks", "Task"),
+                                dispatch_uid="try_to_close_or_open_us_and_milestone_when_delete_task")
+
+    # Tags
+    signals.pre_save.connect(generic_handlers.tags_normalization,
+                             sender=apps.get_model("tasks", "Task"),
+                             dispatch_uid="tags_normalization_task")
+    signals.post_save.connect(generic_handlers.update_project_tags_when_create_or_edit_taggable_item,
+                              sender=apps.get_model("tasks", "Task"),
+                              dispatch_uid="update_project_tags_when_create_or_edit_tagglabe_item_task")
+    signals.post_delete.connect(generic_handlers.update_project_tags_when_delete_taggable_item,
+                                sender=apps.get_model("tasks", "Task"),
+                                dispatch_uid="update_project_tags_when_delete_tagglabe_item_task")
+
+    # Custom Attributes
+    signals.post_save.connect(custom_attributes_handlers.create_custom_attribute_value_when_create_task,
+                              sender=apps.get_model("tasks", "Task"),
+                              dispatch_uid="create_custom_attribute_value_when_create_task")
+
+def disconnect_tasks_signals():
+    signals.pre_save.disconnect(dispatch_uid="cached_prev_task")
+    signals.post_save.disconnect(dispatch_uid="try_to_close_or_open_us_and_milestone_when_create_or_edit_task")
+    signals.post_delete.disconnect(dispatch_uid="try_to_close_or_open_us_and_milestone_when_delete_task")
+    signals.pre_save.disconnect(dispatch_uid="tags_normalization")
+    signals.post_save.disconnect(dispatch_uid="update_project_tags_when_create_or_edit_tagglabe_item")
+    signals.post_delete.disconnect(dispatch_uid="update_project_tags_when_delete_tagglabe_item")
+    signals.post_save.disconnect(dispatch_uid="create_custom_attribute_value_when_create_task")
+
 
 class TasksAppConfig(AppConfig):
     name = "taiga.projects.tasks"
     verbose_name = "Tasks"
 
     def ready(self):
-        # Cached prev object version
-        signals.pre_save.connect(handlers.cached_prev_task,
-                                 sender=apps.get_model("tasks", "Task"))
-
-        # Open/Close US and Milestone
-        signals.post_save.connect(handlers.try_to_close_or_open_us_and_milestone_when_create_or_edit_task,
-                                 sender=apps.get_model("tasks", "Task"))
-        signals.post_delete.connect(handlers.try_to_close_or_open_us_and_milestone_when_delete_task,
-                                    sender=apps.get_model("tasks", "Task"))
-
-        # Tags
-        signals.pre_save.connect(generic_handlers.tags_normalization,
-                                 sender=apps.get_model("tasks", "Task"))
-        signals.post_save.connect(generic_handlers.update_project_tags_when_create_or_edit_taggable_item,
-                                  sender=apps.get_model("tasks", "Task"))
-        signals.post_delete.connect(generic_handlers.update_project_tags_when_delete_taggable_item,
-                                    sender=apps.get_model("tasks", "Task"))
-
-        # Custom Attributes
-        signals.post_save.connect(custom_attributes_handlers.create_custom_attribute_value_when_create_task,
-                                  sender=apps.get_model("tasks", "Task"),
-                                  dispatch_uid="create_custom_attribute_value_when_create_task")
+        connect_tasks_signals()

--- a/taiga/projects/userstories/apps.py
+++ b/taiga/projects/userstories/apps.py
@@ -23,38 +23,61 @@ from taiga.projects.custom_attributes import signals as custom_attributes_handle
 from . import signals as handlers
 
 
-class UserStoriesAppConfig(AppConfig):
-    name = "taiga.projects.userstories"
-    verbose_name = "User Stories"
-
-    def ready(self):
+def connect_userstories_signals():
         # Cached prev object version
         signals.pre_save.connect(handlers.cached_prev_us,
-                                  sender=apps.get_model("userstories", "UserStory"))
+                                 sender=apps.get_model("userstories", "UserStory"),
+                                 dispatch_uid="cached_prev_us")
 
         # Role Points
         signals.post_save.connect(handlers.update_role_points_when_create_or_edit_us,
-                                  sender=apps.get_model("userstories", "UserStory"))
+                                  sender=apps.get_model("userstories", "UserStory"),
+                                  dispatch_uid="update_role_points_when_create_or_edit_us")
 
         # Tasks
         signals.post_save.connect(handlers.update_milestone_of_tasks_when_edit_us,
-                                  sender=apps.get_model("userstories", "UserStory"))
+                                  sender=apps.get_model("userstories", "UserStory"),
+                                  dispatch_uid="update_milestone_of_tasks_when_edit_us")
 
         # Open/Close US and Milestone
         signals.post_save.connect(handlers.try_to_close_or_open_us_and_milestone_when_create_or_edit_us,
-                                 sender=apps.get_model("userstories", "UserStory"))
+                                  sender=apps.get_model("userstories", "UserStory"),
+                                  dispatch_uid="try_to_close_or_open_us_and_milestone_when_create_or_edit_us")
         signals.post_delete.connect(handlers.try_to_close_milestone_when_delete_us,
-                                    sender=apps.get_model("userstories", "UserStory"))
+                                    sender=apps.get_model("userstories", "UserStory"),
+                                    dispatch_uid="try_to_close_milestone_when_delete_us")
 
         # Tags
         signals.pre_save.connect(generic_handlers.tags_normalization,
-                                 sender=apps.get_model("userstories", "UserStory"))
+                                 sender=apps.get_model("userstories", "UserStory"),
+                                 dispatch_uid="tags_normalization_user_story")
         signals.post_save.connect(generic_handlers.update_project_tags_when_create_or_edit_taggable_item,
-                                  sender=apps.get_model("userstories", "UserStory"))
+                                  sender=apps.get_model("userstories", "UserStory"),
+                                  dispatch_uid="update_project_tags_when_create_or_edit_taggable_item_user_story")
         signals.post_delete.connect(generic_handlers.update_project_tags_when_delete_taggable_item,
-                                    sender=apps.get_model("userstories", "UserStory"))
+                                    sender=apps.get_model("userstories", "UserStory"),
+                                    dispatch_uid="update_project_tags_when_delete_taggable_item_user_story")
 
         # Custom Attributes
         signals.post_save.connect(custom_attributes_handlers.create_custom_attribute_value_when_create_user_story,
                                   sender=apps.get_model("userstories", "UserStory"),
                                   dispatch_uid="create_custom_attribute_value_when_create_user_story")
+
+def disconnect_userstories_signals():
+        signals.pre_save.disconnect(dispatch_uid="cached_prev_us")
+        signals.post_save.disconnect(dispatch_uid="update_role_points_when_create_or_edit_us")
+        signals.post_save.disconnect(dispatch_uid="update_milestone_of_tasks_when_edit_us")
+        signals.post_save.disconnect(dispatch_uid="try_to_close_or_open_us_and_milestone_when_create_or_edit_us")
+        signals.post_delete.disconnect(dispatch_uid="try_to_close_milestone_when_delete_us")
+        signals.pre_save.disconnect(dispatch_uid="tags_normalization_user_story")
+        signals.post_save.disconnect(dispatch_uid="update_project_tags_when_create_or_edit_taggable_item_user_story")
+        signals.post_delete.disconnect(dispatch_uid="update_project_tags_when_delete_taggable_item_user_story")
+        signals.post_save.disconnect(dispatch_uid="create_custom_attribute_value_when_create_user_story")
+
+
+class UserStoriesAppConfig(AppConfig):
+    name = "taiga.projects.userstories"
+    verbose_name = "User Stories"
+
+    def ready(self):
+        connect_userstories_signals()


### PR DESCRIPTION
Some projects import and deletion doesn't work correctly because the events app signal is there, I have fixed this, removing the signal handling from import and deletion (now works).

I have refactored a little the connect/discconect signals. In the past when you delete a project, some signals are disconnected and not reconnected, this is fixed too in this commit.