### PR TITLE
Template loader fix & GitLab improvement

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -237,6 +237,11 @@ TEMPLATES = [
             "match_extension": ".jinja",
         }
     },
+    {
+        "BACKEND":'django.template.backends.django.DjangoTemplates',
+        "APP_DIRS": True,
+    },
+    
 ]
 
 


### PR DESCRIPTION
Fixing this template loader error:
```
ERROR:2015-10-13 11:36:29,919: Internal Server Error: /api/v1/
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/django/core/handlers/base.py", line 164, in get_response
    response = response.render()
  File "/usr/lib/python3.4/site-packages/django/template/response.py", line 158, in render
    self.content = self.rendered_content
  File "/srv/http/taiga/taigaio/taiga-back/taiga/base/response.py", line 74, in rendered_content
    ret = renderer.render(self.data, media_type, context)
  File "/srv/http/taiga/taigaio/taiga-back/taiga/base/api/renderers.py", line 607, in render
    template = loader.get_template(self.template)
  File "/usr/lib/python3.4/site-packages/django/template/loader.py", line 46, in get_template
    raise TemplateDoesNotExist(template_name)
django.template.base.TemplateDoesNotExist: api/api.html
[13/Oct/2015 11:36:29] "GET /api/v1/ HTTP/1.1" 500 27
```
Adding improvement to a GitLab event hook so that link to a commit and author name will be displayed along the comment.