### PR TITLE
Add "ref" param to resolver API

### DIFF
--- a/taiga/projects/references/api.py
+++ b/taiga/projects/references/api.py
@@ -59,4 +59,18 @@ class ResolverViewSet(viewsets.ViewSet):
             result["wikipage"] = get_object_or_404(project.wiki_pages.all(),
                                                    slug=data["wikipage"]).pk
 
+        if data["ref"]:
+            if user_has_perm(request.user, "view_us", project):
+                us = project.user_stories.filter(ref=data["ref"]).first()
+                if us:
+                    result["us"] = us.pk
+            if user_has_perm(request.user, "view_tasks", project):
+                task = project.tasks.filter(ref=data["ref"]).first()
+                if task:
+                    result["task"] = task.pk
+            if user_has_perm(request.user, "view_issues", project):
+                issue = project.issues.filter(ref=data["ref"]).first()
+                if issue:
+                    result["issue"] = issue.pk
+
         return response.Ok(result)

--- a/taiga/projects/references/api.py
+++ b/taiga/projects/references/api.py
@@ -60,15 +60,18 @@ class ResolverViewSet(viewsets.ViewSet):
                                                    slug=data["wikipage"]).pk
 
         if data["ref"]:
+            ref_found = False  # No need to continue once one ref is found
             if user_has_perm(request.user, "view_us", project):
                 us = project.user_stories.filter(ref=data["ref"]).first()
                 if us:
                     result["us"] = us.pk
-            if user_has_perm(request.user, "view_tasks", project):
+                    ref_found = True
+            if ref_found is False and user_has_perm(request.user, "view_tasks", project):
                 task = project.tasks.filter(ref=data["ref"]).first()
                 if task:
                     result["task"] = task.pk
-            if user_has_perm(request.user, "view_issues", project):
+                    ref_found = True
+            if ref_found is False and user_has_perm(request.user, "view_issues", project):
                 issue = project.issues.filter(ref=data["ref"]).first()
                 if issue:
                     result["issue"] = issue.pk

--- a/taiga/projects/references/serializers.py
+++ b/taiga/projects/references/serializers.py
@@ -23,4 +23,5 @@ class ResolverSerializer(serializers.Serializer):
     us = serializers.IntegerField(required=False)
     task = serializers.IntegerField(required=False)
     issue = serializers.IntegerField(required=False)
+    ref = serializers.IntegerField(required=False)
     wikipage = serializers.CharField(max_length=512, required=False)

--- a/tests/integration/resources_permissions/test_resolver_resources.py
+++ b/tests/integration/resources_permissions/test_resolver_resources.py
@@ -128,3 +128,21 @@ def test_resolver_list(client, data):
                              "task": data.task.pk,
                              "issue": data.issue.pk,
                              "milestone": data.milestone.pk}
+
+    response = client.json.get("{}?project={}&ref={}".format(url,
+                                                             data.private_project2.slug,
+                                                             data.us.ref))
+    assert response.data == {"project": data.private_project2.pk,
+                             "us": data.us.pk}
+
+    response = client.json.get("{}?project={}&ref={}".format(url,
+                                                             data.private_project2.slug,
+                                                             data.task.ref))
+    assert response.data == {"project": data.private_project2.pk,
+                             "task": data.task.pk}
+
+    response = client.json.get("{}?project={}&ref={}".format(url,
+                                                             data.private_project2.slug,
+                                                             data.issue.ref))
+    assert response.data == {"project": data.private_project2.pk,
+                             "issue": data.issue.pk}


### PR DESCRIPTION
Fixes #489

Added ref GET param to resolver API.
Useful if we know the the ref ID but not the type of object it is.
Reduces number of API calls in cases when we want to reference an object
by it's ref ID.
Modified integration test to confirm ref works just like using a us, ect
params and has same permissions.