### PR TITLE
Added ref GET param to resolver API.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ answer newbie questions, and generally made taiga that much better:
 - Andrés Moya <andres.moya@kaleidos.net>
 - Andrey Alekseenko <al42and@gmail.com>
 - Chris Wilson <chris.wilson@aridhia.com>
+- David Burke <david@burkesoftware.com>
 - Hector Colina <hcolina@gmail.com>
 - Joe Letts
 - Julien Palard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - API: Mixin fields 'users', 'members' and 'memberships' in ProjectDetailSerializer.
 - API: Add stats/system resource with global server stats (total project, total users....)
 - API: Improve and fix some errors in issues/filters_data and userstories/filters_data.
+- API: resolver suport ref GET param and return a story, task or issue.
 - Webhooks: Add deleted datetime to webhooks responses when isues, tasks or USs are deleted.
 - Add headers to allow threading for notification emails about changes to issues, tasks, user stories, and wiki pages. (thanks to [@brett](https://github.com/brettp)).
 - Lots of small and not so small bugfixes.

--- a/taiga/projects/references/api.py
+++ b/taiga/projects/references/api.py
@@ -59,4 +59,21 @@ class ResolverViewSet(viewsets.ViewSet):
             result["wikipage"] = get_object_or_404(project.wiki_pages.all(),
                                                    slug=data["wikipage"]).pk
 
+        if data["ref"]:
+            ref_found = False  # No need to continue once one ref is found
+            if user_has_perm(request.user, "view_us", project):
+                us = project.user_stories.filter(ref=data["ref"]).first()
+                if us:
+                    result["us"] = us.pk
+                    ref_found = True
+            if ref_found is False and user_has_perm(request.user, "view_tasks", project):
+                task = project.tasks.filter(ref=data["ref"]).first()
+                if task:
+                    result["task"] = task.pk
+                    ref_found = True
+            if ref_found is False and user_has_perm(request.user, "view_issues", project):
+                issue = project.issues.filter(ref=data["ref"]).first()
+                if issue:
+                    result["issue"] = issue.pk
+
         return response.Ok(result)

--- a/taiga/projects/references/serializers.py
+++ b/taiga/projects/references/serializers.py
@@ -23,4 +23,16 @@ class ResolverSerializer(serializers.Serializer):
     us = serializers.IntegerField(required=False)
     task = serializers.IntegerField(required=False)
     issue = serializers.IntegerField(required=False)
+    ref = serializers.IntegerField(required=False)
     wikipage = serializers.CharField(max_length=512, required=False)
+
+    def validate(self, attrs):
+        if "ref" in attrs:
+            if "us" in attrs:
+                raise serializers.ValidationError("'us' param is incompatible with 'ref' in the same request")
+            if "task" in attrs:
+                raise serializers.ValidationError("'task' param is incompatible with 'ref' in the same request")
+            if "issue" in attrs:
+                raise serializers.ValidationError("'issue' param is incompatible with 'ref' in the same request")
+
+        return attrs

--- a/tests/integration/resources_permissions/test_resolver_resources.py
+++ b/tests/integration/resources_permissions/test_resolver_resources.py
@@ -128,3 +128,21 @@ def test_resolver_list(client, data):
                              "task": data.task.pk,
                              "issue": data.issue.pk,
                              "milestone": data.milestone.pk}
+
+    response = client.json.get("{}?project={}&ref={}".format(url,
+                                                             data.private_project2.slug,
+                                                             data.us.ref))
+    assert response.data == {"project": data.private_project2.pk,
+                             "us": data.us.pk}
+
+    response = client.json.get("{}?project={}&ref={}".format(url,
+                                                             data.private_project2.slug,
+                                                             data.task.ref))
+    assert response.data == {"project": data.private_project2.pk,
+                             "task": data.task.pk}
+
+    response = client.json.get("{}?project={}&ref={}".format(url,
+                                                             data.private_project2.slug,
+                                                             data.issue.ref))
+    assert response.data == {"project": data.private_project2.pk,
+                             "issue": data.issue.pk}


### PR DESCRIPTION
Useful if we know the the ref ID but not the type of object it is.
Reduces number of API calls in cases when we want to reference an object
by it's ref ID.
Modified integration test to confirm ref works just like using a us, ect
params and has same permissions.

Related to https://github.com/taigaio/taiga-back/pull/491 with tests and params validator