### PR TITLE
Fix TypeErrors: sequence item expected str instance, NoneType found

### DIFF
--- a/taiga/projects/history/templatetags/functions.py
+++ b/taiga/projects/history/templatetags/functions.py
@@ -40,4 +40,12 @@ def verbose_name(obj_class, field_name):
 
 @library.global_function
 def lists_diff(list1, list2):
-    return (list(set(list1) - set(list2)))
+    """
+    Get the difference of two list and remove None values.
+
+    >>> list1 = ["a", None, "b", "c"]
+    >>> list2 = [None, "b", "d", "e"]
+    >>> list(filter(None.__ne__, set(list1) - set(list2)))
+    ['c', 'a']
+    """
+    return list(filter(None.__ne__, set(list1) - set(list2)))


### PR DESCRIPTION
For example:
 
```
','.join([None, 'a', 'b'])
```


Related to https://github.com/taigaio/taiga-back/pull/498