### PR TITLE
Remove usage of django.core.files.storage.Storage.path

### DIFF
--- a/taiga/export_import/api.py
+++ b/taiga/export_import/api.py
@@ -68,8 +68,7 @@ class ProjectExporterViewSet(mixins.ImportThrottlingPolicyMixin, GenericViewSet)
             return response.Accepted({"export_id": task.id})
 
         path = "exports/{}/{}-{}.json".format(project.pk, project.slug, uuid.uuid4().hex)
-        storage_path = default_storage.path(path)
-        with default_storage.open(storage_path, mode="w") as outfile:
+        with default_storage.open(path, mode="w") as outfile:
             service.render_project(project, outfile)
 
         response_data = {

--- a/taiga/export_import/tasks.py
+++ b/taiga/export_import/tasks.py
@@ -40,11 +40,10 @@ import resource
 @app.task(bind=True)
 def dump_project(self, user, project):
     path = "exports/{}/{}-{}.json".format(project.pk, project.slug, self.request.id)
-    storage_path = default_storage.path(path)
 
     try:
         url = default_storage.url(path)
-        with default_storage.open(storage_path, mode="w") as outfile:
+        with default_storage.open(path, mode="w") as outfile:
             render_project(project, outfile)
 
     except Exception:

--- a/taiga/users/models.py
+++ b/taiga/users/models.py
@@ -251,8 +251,8 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         # Removing original photo
         if self.photo:
-            storage, path = self.photo.storage, self.photo.path
-            storage.delete(path)
+            storage, name = self.photo.storage, self.photo.name
+            storage.delete(name)
 
         self.photo = None
 


### PR DESCRIPTION
When using an alternate default storage (like S3 with django-storages) `django.core.files.storage.Storage.path` raises NotImplementedError. Fixes #554

These changes allow me to use S3 as my file storage with my install of Taiga. Hopefully these changes don't break users that are using the default `django.core.files.storage.FileSystemStorage`. I couldn't think of a reason to use the full filesystem path, but perhaps I'm missing something.
