### PR TITLE
Issue 3543 - Webhooks: problem extracting the story points from a user story

### DIFF
--- a/taiga/webhooks/signal_handlers.py
+++ b/taiga/webhooks/signal_handlers.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from django.db import connection
 from django.conf import settings
 from django.utils import timezone
 
@@ -62,6 +63,6 @@ def on_new_history_entry(sender, instance, created, **kwargs):
         args = [webhook["id"], webhook["url"], webhook["key"], obj] + extra_args
 
         if settings.CELERY_ENABLED:
-            task.delay(*args)
+            connection.on_commit(lambda: task.delay(*args))
         else:
-            task(*args)
+            connection.on_commit(lambda: task(*args))

--- a/tests/integration/test_webhooks.py
+++ b/tests/integration/test_webhooks.py
@@ -23,7 +23,7 @@ from .. import factories as f
 
 from taiga.projects.history import services
 
-pytestmark = pytest.mark.django_db
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 def test_new_object_with_one_webhook(settings):


### PR DESCRIPTION
The problem was related to the use of Celery. The task was launched before the database had fully commited the update on the m2m relations of the object, now the task is launched when the database transaction is finished.