### PR TITLE
Add sprint name to user stories search result

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ answer newbie questions, and generally made taiga that much better:
 - Andrey Alekseenko <al42and@gmail.com>
 - Chris Wilson <chris.wilson@aridhia.com>
 - David Burke <david@burkesoftware.com>
+- Everardo Medina <everblut@gmail.com>
 - Hector Colina <hcolina@gmail.com>
 - Joe Letts
 - Julien Palard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Transfer projects ownership support
 - Customizable max private and public projects per user
 - Customizable max of memberships per owned private and public projects
+- Add Sprint name and slug on search results for User Stories
 
 ### Misc
 - Lots of small and not so small bugfixes.

--- a/taiga/searches/serializers.py
+++ b/taiga/searches/serializers.py
@@ -41,7 +41,7 @@ class TaskSearchResultsSerializer(TaskSerializer):
 class UserStorySearchResultsSerializer(UserStorySerializer):
     class Meta:
         model = UserStory
-        fields = ('id', 'ref', 'subject', 'status', 'total_points')
+        fields = ('id', 'ref', 'subject', 'status', 'total_points', 'milestone_name')
 
 
 class WikiPageSearchResultsSerializer(WikiPageSerializer):

--- a/taiga/searches/serializers.py
+++ b/taiga/searches/serializers.py
@@ -41,7 +41,8 @@ class TaskSearchResultsSerializer(TaskSerializer):
 class UserStorySearchResultsSerializer(UserStorySerializer):
     class Meta:
         model = UserStory
-        fields = ('id', 'ref', 'subject', 'status', 'total_points', 'milestone_name')
+        fields = ('id', 'ref', 'subject', 'status', 'total_points',
+                  'milestone_name', 'milestone_slug')
 
 
 class WikiPageSearchResultsSerializer(WikiPageSerializer):


### PR DESCRIPTION
Hi

i'm adding the sprint name to the columns displayed in the user stories search results.

The taiga-front PR for this enhancement is open 

:v: 