### PR TITLE
Removed 'load url from future' for compatibility with Django 1.9

### DIFF
--- a/taiga/base/api/templates/api/base.html
+++ b/taiga/base/api/templates/api/base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load api %}
 <!DOCTYPE html>
 <html>

--- a/taiga/base/api/templates/api/login_base.html
+++ b/taiga/base/api/templates/api/login_base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load api %}
 <html>
 


### PR DESCRIPTION
Since taiga-back is based on Django 1.9, it generates TemplateSyntaxError error: 'url' is not a valid tag or filter in tag library 'future' which is loaded implicitly in 1.9.