### PR TITLE
Fix missing import of Http404

### DIFF
--- a/taiga/projects/api.py
+++ b/taiga/projects/api.py
@@ -26,6 +26,7 @@ from django.db.models.functions import Coalesce
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 from django.utils import timezone
+from django.http import Http404
 
 from taiga.base import filters
 from taiga.base import response


### PR DESCRIPTION
https://github.com/taigaio/taiga-back/blob/master/taiga/projects/api.py#L431

There was no import of Http404 though there was the usage of it, which causes an import error.