### PR TITLE
Avoid accessing an attribute of a NoneType object

### DIFF
--- a/taiga/projects/notifications/mixins.py
+++ b/taiga/projects/notifications/mixins.py
@@ -239,13 +239,14 @@ class EditableWatchedResourceModelSerializer(WatchedResourceModelSerializer):
 
     def to_native(self, obj):
         #if watchers wasn't attached via the get_queryset of the viewset we need to manually add it
-        if obj is not None and not hasattr(obj, "watchers"):
-            obj.watchers = [user.id for user in obj.get_watchers()]
+        if obj is not None:
+            if not hasattr(obj, "watchers"):
+                obj.watchers = [user.id for user in obj.get_watchers()]
 
-        request = self.context.get("request", None)
-        user = request.user if request else None
-        if user and user.is_authenticated():
-            obj.is_watcher = user.id in obj.watchers
+            request = self.context.get("request", None)
+            user = request.user if request else None
+            if user and user.is_authenticated():
+                obj.is_watcher = user.id in obj.watchers
 
         return super(WatchedResourceModelSerializer, self).to_native(obj)
 


### PR DESCRIPTION
https://github.com/taigaio/taiga-back/blob/master/taiga/projects/notifications/mixins.py#L248

`obj.is_watcher = user.id in obj.watcher`

Obviously, this code will raise an error when "obj" is a NoneType object. 