### PR TITLE
Don't use the user's username in the project's slug. TG-3908

### DIFF
--- a/taiga/projects/models.py
+++ b/taiga/projects/models.py
@@ -296,7 +296,7 @@ class Project(ProjectDefaults, TaggedMixin, models.Model):
             self.modified_date = timezone.now()
 
         if not self.slug:
-            base_name = "{}-{}".format(self.owner.username, self.name)
+            base_name = "{}".format(self.name)
             base_slug = slugify_uniquely(base_name, self.__class__)
             slug = base_slug
             for i in arithmetic_progression():


### PR DESCRIPTION
The existing code already ensured the slug yield zero collisions by querying the model for existing projects with the same slug and adding an incremental number to the new slug if a match is found. I searched the frontend repository but couldn't find any where this change will require changes in that repository.

If I'm missing something please let me know.

CC @EstherMoreno 
