### PR TITLE
Fixing burndown graph

### DIFF
--- a/taiga/projects/services/stats.py
+++ b/taiga/projects/services/stats.py
@@ -196,8 +196,10 @@ def _get_milestones_stats_for_backlog(project, milestones):
 
         else:
             milestone_name = _("Future sprint")
-            team_increment = current_team_increment + project._future_team_increment,
-            client_increment = current_client_increment + project._future_client_increment,
+            current_team_increment += project._future_team_increment
+            current_client_increment += project._future_client_increment
+            team_increment = current_team_increment
+            client_increment = current_client_increment
             current_evolution = None
 
         milestones_stats.append({
@@ -216,8 +218,8 @@ def _get_milestones_stats_for_backlog(project, milestones):
         'name': _('Project End'),
         'optimal': optimal_points,
         'evolution': evolution,
-        'team-increment': team_increment,
-        'client-increment': client_increment,
+        'team-increment': current_team_increment,
+        'client-increment': current_client_increment,
     })
 
     return milestones_stats


### PR DESCRIPTION
The problem was related to the ending point of the graph, if team or client requirement points were added on the last sprint it wasn't properly reflected on the graph