### PR TITLE
Fix issue #4094: Add 'estimated start' and 'estimated end' sprint dates to CSV reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
     - add the date of the notification ('date' field)
     - show human diffs in 'changes'
     - remove unnecessary data
+- CSV Reports:
+    - Change field name: 'milestone' to 'sprint'
+    - Add new fields: 'sprint_estimated_start' and 'sprint_estimated_end'
 
 ### Misc
 - Add sprint name and slug on search results for user stories ((thanks to [@everblut](https://github.com/everblut)))

--- a/taiga/projects/issues/services.py
+++ b/taiga/projects/issues/services.py
@@ -84,12 +84,11 @@ def update_issues_order_in_bulk(bulk_data):
 
 def issues_to_csv(project, queryset):
     csv_data = io.StringIO()
-    fieldnames = ["ref", "subject", "description", "milestone", "owner",
-                  "owner_full_name", "assigned_to", "assigned_to_full_name",
-                  "status", "severity", "priority", "type", "is_closed",
-                  "attachments", "external_reference", "tags",
-                  "watchers", "voters",
-                  "created_date", "modified_date", "finished_date"]
+    fieldnames = ["ref", "subject", "description", "sprint", "sprint_estimated_start",
+                  "sprint_estimated_finish", "owner", "owner_full_name", "assigned_to",
+                  "assigned_to_full_name", "status", "severity", "priority", "type",
+                  "is_closed", "attachments", "external_reference", "tags", "watchers",
+                  "voters", "created_date", "modified_date", "finished_date"]
 
     custom_attrs = project.issuecustomattributes.all()
     for custom_attr in custom_attrs:
@@ -112,7 +111,9 @@ def issues_to_csv(project, queryset):
             "ref": issue.ref,
             "subject": issue.subject,
             "description": issue.description,
-            "milestone": issue.milestone.name if issue.milestone else None,
+            "sprint": issue.milestone.name if issue.milestone else None,
+            "sprint_estimated_start": issue.milestone.estimated_start if issue.milestone else None,
+            "sprint_estimated_finish": issue.milestone.estimated_finish if issue.milestone else None,
             "owner": issue.owner.username if issue.owner else None,
             "owner_full_name": issue.owner.get_full_name() if issue.owner else None,
             "assigned_to": issue.assigned_to.username if issue.assigned_to else None,

--- a/taiga/projects/tasks/services.py
+++ b/taiga/projects/tasks/services.py
@@ -95,11 +95,10 @@ def snapshot_tasks_in_bulk(bulk_data, user):
 
 def tasks_to_csv(project, queryset):
     csv_data = io.StringIO()
-    fieldnames = ["ref", "subject", "description", "user_story", "milestone", "owner",
-                  "owner_full_name", "assigned_to", "assigned_to_full_name",
-                  "status", "is_iocaine", "is_closed", "us_order",
-                  "taskboard_order", "attachments", "external_reference", "tags",
-                  "watchers", "voters"]
+    fieldnames = ["ref", "subject", "description", "user_story", "sprint", "sprint_estimated_start",
+                  "sprint_estimated_finish", "owner", "owner_full_name", "assigned_to",
+                  "assigned_to_full_name", "status", "is_iocaine", "is_closed", "us_order",
+                  "taskboard_order", "attachments", "external_reference", "tags", "watchers", "voters"]
 
     custom_attrs = project.taskcustomattributes.all()
     for custom_attr in custom_attrs:
@@ -124,7 +123,9 @@ def tasks_to_csv(project, queryset):
             "subject": task.subject,
             "description": task.description,
             "user_story": task.user_story.ref if task.user_story else None,
-            "milestone": task.milestone.name if task.milestone else None,
+            "sprint": task.milestone.name if task.milestone else None,
+            "sprint_estimated_start": task.milestone.estimated_start if task.milestone else None,
+            "sprint_estimated_finish": task.milestone.estimated_finish if task.milestone else None,
             "owner": task.owner.username if task.owner else None,
             "owner_full_name": task.owner.get_full_name() if task.owner else None,
             "assigned_to": task.assigned_to.username if task.assigned_to else None,

--- a/taiga/projects/userstories/services.py
+++ b/taiga/projects/userstories/services.py
@@ -130,9 +130,9 @@ def open_userstory(us):
 
 def userstories_to_csv(project,queryset):
     csv_data = io.StringIO()
-    fieldnames = ["ref", "subject", "description", "milestone", "owner",
-                  "owner_full_name", "assigned_to", "assigned_to_full_name",
-                  "status", "is_closed"]
+    fieldnames = ["ref", "subject", "description", "sprint", "sprint_estimated_start",
+                  "sprint_estimated_finish", "owner", "owner_full_name", "assigned_to",
+                  "assigned_to_full_name", "status", "is_closed"]
 
     roles = project.roles.filter(computable=True).order_by('slug')
     for role in roles:
@@ -144,8 +144,7 @@ def userstories_to_csv(project,queryset):
                    "created_date", "modified_date", "finish_date",
                    "client_requirement", "team_requirement", "attachments",
                    "generated_from_issue", "external_reference", "tasks",
-                   "tags",
-                   "watchers", "voters"]
+                   "tags","watchers", "voters"]
 
     custom_attrs = project.userstorycustomattributes.all()
     for custom_attr in custom_attrs:
@@ -174,7 +173,9 @@ def userstories_to_csv(project,queryset):
             "ref": us.ref,
             "subject": us.subject,
             "description": us.description,
-            "milestone": us.milestone.name if us.milestone else None,
+            "sprint": us.milestone.name if us.milestone else None,
+            "sprint_estimated_start": us.milestone.estimated_start if us.milestone else None,
+            "sprint_estimated_finish": us.milestone.estimated_finish if us.milestone else None,
             "owner": us.owner.username if us.owner else None,
             "owner_full_name": us.owner.get_full_name() if us.owner else None,
             "assigned_to": us.assigned_to.username if us.assigned_to else None,

--- a/tests/integration/test_issues.py
+++ b/tests/integration/test_issues.py
@@ -433,6 +433,6 @@ def test_custom_fields_csv_generation():
     data.seek(0)
     reader = csv.reader(data)
     row = next(reader)
-    assert row[21] == attr.name
+    assert row[23] == attr.name
     row = next(reader)
-    assert row[21] == "val1"
+    assert row[23] == "val1"

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -64,7 +64,7 @@ def test_create_task_without_default_values(client):
     response = client.json.post(url, json.dumps(data))
     assert response.status_code == 201
     assert response.data['status'] == None
-    
+
 
 def test_api_update_task_tags(client):
     project = f.ProjectFactory.create()
@@ -176,6 +176,6 @@ def test_custom_fields_csv_generation():
     data.seek(0)
     reader = csv.reader(data)
     row = next(reader)
-    assert row[19] == attr.name
+    assert row[21] == attr.name
     row = next(reader)
-    assert row[19] == "val1"
+    assert row[21] == "val1"

--- a/tests/integration/test_userstories.py
+++ b/tests/integration/test_userstories.py
@@ -469,9 +469,9 @@ def test_custom_fields_csv_generation():
     data.seek(0)
     reader = csv.reader(data)
     row = next(reader)
-    assert row[26] == attr.name
+    assert row[28] == attr.name
     row = next(reader)
-    assert row[26] == "val1"
+    assert row[28] == "val1"
 
 
 def test_update_userstory_respecting_watchers(client):


### PR DESCRIPTION
- "milestone" -> "sprint"
- + "sprint_estimated_start"
- + "sprint_estimated_finish"