### PR TITLE
Made minor fixes over load_dump and dump_project commands

### DIFF
--- a/taiga/export_import/management/commands/dump_project.py
+++ b/taiga/export_import/management/commands/dump_project.py
@@ -24,7 +24,7 @@ import os
 
 
 class Command(BaseCommand):
-    help = "Export projects to json"
+    help = "Export projects to a json file"
 
     def add_arguments(self, parser):
         parser.add_argument("project_slugs",
@@ -56,7 +56,7 @@ class Command(BaseCommand):
                 raise CommandError("Project '{}' does not exist".format(project_slug))
 
             dst_file = os.path.join(dst_dir, "{}.json".format(project_slug))
-            with open(src_file, "w") as f:
+            with open(dst_file, "w") as f:
                 render_project(project, f)
 
-            print("-> Generate dump of project '{}' in '{}'".format(project.name, src_file))
+            print("-> Generate dump of project '{}' in '{}'".format(project.name, dst_file))


### PR DESCRIPTION
```bash
> ./manage.py load_dump
```
```
Trying import local.py settings...
usage: manage.py load_dump [-h] [--version] [-v {0,1,2,3}]
                           [--settings SETTINGS] [--pythonpath PYTHONPATH]
                           [--traceback] [--no-color] [-o]
                           dump_file owner_email
manage.py load_dump: error: the following arguments are required: dump_file, owner_email
```
   
   
```bash
> ./manage.py load_dump --help
```
```
Trying import local.py settings...
usage: manage.py load_dump [-h] [--version] [-v {0,1,2,3}]
                           [--settings SETTINGS] [--pythonpath PYTHONPATH]
                           [--traceback] [--no-color] [-o]
                           dump_file owner_email

Import a project from a json file

positional arguments:
  dump_file             The path to a dump file (.json).
  owner_email           The email of the new project owner.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  -o, --overwrite       Overwrite the project if exists
```