### PR TITLE
Ugly hack to temporary disable thumbnail generation for tiff files

### DIFF
--- a/taiga/base/utils/thumbnails.py
+++ b/taiga/base/utils/thumbnails.py
@@ -15,6 +15,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
+from django.db.models.fields.files import FieldFile
+
 from taiga.base.utils.urls import get_absolute_url
 
 from easy_thumbnails.files import get_thumbnailer
@@ -22,6 +26,15 @@ from easy_thumbnails.exceptions import InvalidImageFormatError
 
 
 def get_thumbnail_url(file_obj, thumbnailer_size):
+    # Ugly hack to temporary ignore tiff files
+    relative_name = file_obj
+    if isinstance(file_obj, FieldFile):
+        relative_name = file_obj.name
+
+    source_extension = os.path.splitext(relative_name)[1][1:]
+    if source_extension == "tiff":
+        return None
+
     try:
         path_url = get_thumbnailer(file_obj)[thumbnailer_size].url
         thumb_url = get_absolute_url(path_url)


### PR DESCRIPTION
Tiff thumbnail generation keeps failing because of: https://github.com/python-pillow/Pillow/issues/1462

This a temporary alternative to disable it if the image has tiff extension