### PR TITLE
Generating application token only when it doesn't exist

### DIFF
--- a/taiga/external_apps/models.py
+++ b/taiga/external_apps/models.py
@@ -83,4 +83,5 @@ class ApplicationToken(models.Model):
 
     def generate_token(self):
         self.auth_code = None
-        self.token = _generate_uuid()
+        if not self.token:
+            self.token = _generate_uuid()


### PR DESCRIPTION
If we always generate a new token when calling to the validate API we can't match the users if for example the email fails. We should talk about this with Andrés too before merging.