### PR TITLE
Update bleach to 1.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ celery==3.1.20
 redis==2.10.5
 Unidecode==0.04.19
 raven==5.10.2
-bleach==1.4.2
+bleach==1.4.3
 django-ipware==1.1.3
 premailer==2.9.7
 cssutils==1.0.1                 # Compatible with python 3.5


### PR DESCRIPTION
```
Changes in Bleach Version 1.4.3 (May 23rd, 2016)
  - Limit to html5lib >=0.999<0.99999999 because of impending change to sanitizer api. #195
```

Without this PR, Taiga fails to be built / work:

```
Downloading/unpacking contextlib2 (from raven==5.10.2->-r requirements.txt (line 27))
  Downloading contextlib2-0.5.3-py2.py3-none-any.whl
Downloading/unpacking html5lib>=0.999 (from bleach==1.4.2->-r requirements.txt (line 28))
  Downloading html5lib-0.999999999.tar.gz (245kB): 245kB downloaded
  Ignoring link https://pypi.python.org/packages/f6/89/c388a695d6a3d274c27c113d2e489c517bf1db8ab7e9b9ee1f8f41f69aad/html5lib-0.10.tar.gz#md5=48a0c483ae4e8aa71d1703cf4837c52a (from https://pypi.python.org/simple/html5lib/), version 0.10 doesn't match >=0.999
  Using version 0.999999999 (newest of versions: 0.999999999, 0.99999999, 0.9999999, 0.999999, 0.99999, 0.9999, 0.999)
  Downloading from URL https://pypi.python.org/packages/17/ee/99e69cdcefc354e0c18ff2cc60aeeb5bfcc2e33f051bf0cc5526d790c445/html5lib-0.999999999.tar.gz#md5=8578e4e3a341436cb9743a9e4a299239 (from https://pypi.python.org/simple/html5lib/)
  Running setup.py (path:/tmp/pip-build-sbgms69o/html5lib/setup.py) egg_info for package html5lib

    html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 5.5.1)
    Complete output from command python setup.py egg_info:
    html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 5.5.1)

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /tmp/pip-build-sbgms69o/html5lib
Storing debug log for failure in /home/taiga/.pip/pip.log
```

```
  File "/opt/taiga/taiga-back/taiga/projects/models.py", line 47, in <module>
    from taiga.projects.notifications.services import (
  File "/opt/taiga/taiga-back/taiga/projects/notifications/services.py", line 36, in <module>
    from taiga.projects.history.services import (make_key_from_model_object,
  File "/opt/taiga/taiga-back/taiga/projects/history/services.py", line 47, in <module>
    from taiga.mdrender.service import render as mdrender
  File "/opt/taiga/taiga-back/taiga/mdrender/service.py", line 21, in <module>
    import bleach
  File "/opt/taiga/venvtaiga/lib/python3.4/site-packages/bleach/__init__.py", line 8, in <module>
    from html5lib.sanitizer import HTMLSanitizer
ImportError: No module named 'html5lib.sanitizer'
```
