### PR TITLE
Adds created-, modified-, finished- and finish_date filters to issues, tasks and userstories (if applicable)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,6 +29,7 @@ answer newbie questions, and generally made taiga that much better:
 - Joe Letts
 - Julien Palard
 - luyikei <luyikei.qmltu@gmail.com>
+- Michael Jurke <m.jurke@gmx.de>
 - Motius GmbH <mail@motius.de>
 - Riccardo Coccioli <riccardo.coccioli@immobiliare.it>
 - Ricky Posner <e@eposner.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
     - Improve messages generated on webhooks input.
     - Add mentions support in commit messages.
     - Cleanup hooks code.
+- Add created-, modified-, finished- and finish_date queryset filters
+    - Support exact match, gt, gte, lt, lte
 
 ### Misc
 - [API] Improve performance of some calls over list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
     - Cleanup hooks code.
 - Add created-, modified-, finished- and finish_date queryset filters
     - Support exact match, gt, gte, lt, lte
+    - added issues, tasks and userstories accordingly
 
 ### Misc
 - [API] Improve performance of some calls over list.

--- a/taiga/projects/issues/api.py
+++ b/taiga/projects/issues/api.py
@@ -58,7 +58,10 @@ class IssueViewSet(OCCResourceMixin, VotedResourceMixin, HistoryResourceMixin, W
                        filters.TagsFilter,
                        filters.WatchersFilter,
                        filters.QFilter,
-                       filters.OrderByFilterMixin)
+                       filters.OrderByFilterMixin,
+                       filters.CreatedDateFilter,
+                       filters.ModifiedDateFilter,
+                       filters.FinishedDateFilter)
     retrieve_exclude_filters = (filters.OwnersFilter,
                                 filters.AssignedToFilter,
                                 filters.StatusesFilter,

--- a/taiga/projects/tasks/api.py
+++ b/taiga/projects/tasks/api.py
@@ -56,7 +56,10 @@ class TaskViewSet(OCCResourceMixin, VotedResourceMixin, HistoryResourceMixin,
                        filters.StatusesFilter,
                        filters.TagsFilter,
                        filters.WatchersFilter,
-                       filters.QFilter)
+                       filters.QFilter,
+                       filters.CreatedDateFilter,
+                       filters.ModifiedDateFilter,
+                       filters.FinishedDateFilter)
     retrieve_exclude_filters = (filters.OwnersFilter,
                                 filters.AssignedToFilter,
                                 filters.StatusesFilter,

--- a/taiga/projects/userstories/api.py
+++ b/taiga/projects/userstories/api.py
@@ -64,7 +64,10 @@ class UserStoryViewSet(OCCResourceMixin, VotedResourceMixin, HistoryResourceMixi
                        filters.TagsFilter,
                        filters.WatchersFilter,
                        filters.QFilter,
-                       filters.OrderByFilterMixin)
+                       filters.OrderByFilterMixin,
+                       filters.CreatedDateFilter,
+                       filters.ModifiedDateFilter,
+                       filters.FinishDateFilter)
     retrieve_exclude_filters = (filters.OwnersFilter,
                                 filters.AssignedToFilter,
                                 filters.StatusesFilter,

--- a/tests/integration/test_issues.py
+++ b/tests/integration/test_issues.py
@@ -19,6 +19,10 @@
 
 import uuid
 import csv
+import pytz
+
+from datetime import datetime, timedelta
+from urllib.parse import quote
 
 from unittest import mock
 
@@ -219,6 +223,103 @@ def test_api_filter_by_text_6(client):
 
     assert response.status_code == 200
     assert number_of_issues == 1
+
+
+def test_api_filter_by_created_date(client):
+    user = f.UserFactory(is_superuser=True)
+    one_day_ago = datetime.now(pytz.utc) - timedelta(days=1)
+
+    old_issue = f.create_issue(owner=user, created_date=one_day_ago)
+    issue = f.create_issue(owner=user)
+
+    url = reverse("issues-list") + "?created_date=%s" % (
+        quote(issue.created_date.isoformat())
+    )
+
+    client.login(issue.owner)
+    response = client.get(url)
+    number_of_issues = len(response.data)
+
+    assert response.status_code == 200
+    assert number_of_issues == 1
+    assert response.data[0]["ref"] == issue.ref
+
+
+def test_api_filter_by_created_date__gt(client):
+    user = f.UserFactory(is_superuser=True)
+    one_day_ago = datetime.now(pytz.utc) - timedelta(days=1)
+
+    old_issue = f.create_issue(owner=user, created_date=one_day_ago)
+    issue = f.create_issue(owner=user)
+
+    url = reverse("issues-list") + "?created_date__gt=%s" % (
+        quote(one_day_ago.isoformat())
+    )
+
+    client.login(issue.owner)
+    response = client.get(url)
+    number_of_issues = len(response.data)
+
+    assert response.status_code == 200
+    assert number_of_issues == 1
+    assert response.data[0]["ref"] == issue.ref
+
+
+def test_api_filter_by_created_date__gte(client):
+    user = f.UserFactory(is_superuser=True)
+    one_day_ago = datetime.now(pytz.utc) - timedelta(days=1)
+
+    old_issue = f.create_issue(owner=user, created_date=one_day_ago)
+    issue = f.create_issue(owner=user)
+
+    url = reverse("issues-list") + "?created_date__gte=%s" % (
+        quote(one_day_ago.isoformat())
+    )
+
+    client.login(issue.owner)
+    response = client.get(url)
+    number_of_issues = len(response.data)
+
+    assert response.status_code == 200
+    assert number_of_issues == 2
+
+
+def test_api_filter_by_created_date__lt(client):
+    user = f.UserFactory(is_superuser=True)
+    one_day_ago = datetime.now(pytz.utc) - timedelta(days=1)
+
+    old_issue = f.create_issue(owner=user, created_date=one_day_ago)
+    issue = f.create_issue(owner=user)
+
+    url = reverse("issues-list") + "?created_date__lt=%s" % (
+        quote(issue.created_date.isoformat())
+    )
+
+    client.login(issue.owner)
+    response = client.get(url)
+    number_of_issues = len(response.data)
+
+    assert response.status_code == 200
+    assert response.data[0]["ref"] == old_issue.ref
+
+
+def test_api_filter_by_created_date__lte(client):
+    user = f.UserFactory(is_superuser=True)
+    one_day_ago = datetime.now(pytz.utc) - timedelta(days=1)
+
+    old_issue = f.create_issue(owner=user, created_date=one_day_ago)
+    issue = f.create_issue(owner=user)
+
+    url = reverse("issues-list") + "?created_date__lte=%s" % (
+        quote(issue.created_date.isoformat())
+    )
+
+    client.login(issue.owner)
+    response = client.get(url)
+    number_of_issues = len(response.data)
+
+    assert response.status_code == 200
+    assert number_of_issues == 2
 
 
 def test_api_filters_data(client):


### PR DESCRIPTION
This PR adds the possibility to filter issues by date (gt, gte, lt, lte on created_date, modified_date and finished_date), so enhancements and extension from taiga frontend could use them. If the general approach finds acceptance, I would like to extend it for user stories and tasks and will update the docs accordingly.

Please provide feedback

* if a PR to extend the API with this features can be successful
* if the general approach of this PR is alright as well as the tests
* if not, what needs to be added, changed or how it could be implemented instead to be accepted

Thanks!