### PR TITLE
Rework webhook signature header to align with defined standards and implementations

### DIFF
--- a/taiga/webhooks/tasks.py
+++ b/taiga/webhooks/tasks.py
@@ -66,7 +66,8 @@ def _send_request(webhook_id, url, key, data):
     serialized_data = UnicodeJSONRenderer().render(data)
     signature = _generate_signature(serialized_data, key)
     headers = {
-        "X-Hub-Signature": "sha1=" + signature,
+        "X-TAIGA-WEBHOOK-SIGNATURE": signature,        # For backward compatibility
+        "X-Hub-Signature": "sha1={}".format(signature),
         "Content-Type": "application/json"
     }
     request = requests.Request('POST', url, data=serialized_data, headers=headers)

--- a/taiga/webhooks/tasks.py
+++ b/taiga/webhooks/tasks.py
@@ -66,7 +66,7 @@ def _send_request(webhook_id, url, key, data):
     serialized_data = UnicodeJSONRenderer().render(data)
     signature = _generate_signature(serialized_data, key)
     headers = {
-        "X-TAIGA-WEBHOOK-SIGNATURE": signature,
+        "X-Hub-Signature": "sha1=" + signature,
         "Content-Type": "application/json"
     }
     request = requests.Request('POST', url, data=serialized_data, headers=headers)


### PR DESCRIPTION
As the maintainer of a generic Webhooks receiver module for Drupal 8 I got a feature request to support the verification of the Taiga Webhook signature header at https://www.drupal.org/node/2795445

Being aware that there is no strong standard or RFC around Webhooks, when implementing the verification mechanism in that module we tried to stick to the standards available and the existing implementations of the larger players like Github [1] and Facebook [2].

Especially the signature mechanism also used by Github and Facebook is well defined in the working draft of PubSubHubbub [3]. This working draft defines a fixed naming for the signature header and specifies the value of the attribute to be algo=signature. That allows for fast and reliable detection of a signature, it allows the receiver to identify the algorithm used to calculate the signature and so allows to verify it without further knowledge of the originator.

As it is tedious to implement all the possible variations of a signature of this kind, it would be really nice have a common denominator to build upon. Please consider to adjust your implementation to be compatible with that defined in the PubSubHubbub working draft.

[1] https://developer.github.com/webhooks/securing/
[2] https://developers.facebook.com/docs/graph-api/webhooks#receiveupdates
[3] https://superfeedr-misc.s3.amazonaws.com/pubsubhubbub-core-0.4.html#authednotify