### PR TITLE
Fixes CharField behaviour and introduces proper validation for ModelField

### DIFF
--- a/taiga/base/api/fields.py
+++ b/taiga/base/api/fields.py
@@ -467,6 +467,11 @@ class ModelField(WritableField):
             "type": self.model_field.get_internal_type()
         }
 
+    def validate(self, value):
+        super(ModelField, self).validate(value)
+        if value is None and not self.model_field.null:
+            raise ValidationError(self.error_messages['invalid'])
+
 
 ##### Typed Fields #####
 
@@ -512,8 +517,9 @@ class CharField(WritableField):
             self.validators.append(validators.MaxLengthValidator(max_length))
 
     def from_native(self, value):
-        if isinstance(value, six.string_types) or value is None:
-            return value
+        if value in validators.EMPTY_VALUES:
+            return ""
+            
         return smart_text(value)
 
     def to_native(self, value):


### PR DESCRIPTION
There was an issue in DRF for CharFields with null=False and blank=True when a PATCH sends a null value for the field.

In taiga you can try reproducing the issue with something like:

`curl 'http://localhost:8000/api/v1/issues' -H 'Content-Type: application/json' -H 'Authorization: Bearer XXXXX' --data-binary '{"project":5,"subject":"test", "description": null}'`

It's a backport from https://github.com/tomchristie/django-rest-framework/pull/1669/files