### PR TITLE
Add project extra info to issues, tasks and milestones list serializers

### DIFF
--- a/taiga/projects/epics/serializers.py
+++ b/taiga/projects/epics/serializers.py
@@ -23,6 +23,7 @@ from taiga.base.neighbors import NeighborsSerializerMixin
 from taiga.mdrender.service import render as mdrender
 from taiga.projects.attachments.serializers import BasicAttachmentsInfoSerializerMixin
 from taiga.projects.mixins.serializers import OwnerExtraInfoSerializerMixin
+from taiga.projects.mixins.serializers import ProjectExtraInfoSerializerMixin
 from taiga.projects.mixins.serializers import AssignedToExtraInfoSerializerMixin
 from taiga.projects.mixins.serializers import StatusExtraInfoSerializerMixin
 from taiga.projects.notifications.mixins import WatchedResourceSerializer
@@ -32,7 +33,8 @@ from taiga.projects.votes.mixins.serializers import VoteResourceSerializerMixin
 
 class EpicListSerializer(VoteResourceSerializerMixin, WatchedResourceSerializer,
                          OwnerExtraInfoSerializerMixin, AssignedToExtraInfoSerializerMixin,
-                         StatusExtraInfoSerializerMixin, BasicAttachmentsInfoSerializerMixin,
+                         StatusExtraInfoSerializerMixin, ProjectExtraInfoSerializerMixin,
+                         BasicAttachmentsInfoSerializerMixin,
                          TaggedInProjectResourceSerializer, serializers.LightSerializer):
 
     id = Field()

--- a/taiga/projects/issues/serializers.py
+++ b/taiga/projects/issues/serializers.py
@@ -22,6 +22,7 @@ from taiga.base.neighbors import NeighborsSerializerMixin
 
 from taiga.mdrender.service import render as mdrender
 from taiga.projects.mixins.serializers import OwnerExtraInfoSerializerMixin
+from taiga.projects.mixins.serializers import ProjectExtraInfoSerializerMixin
 from taiga.projects.mixins.serializers import AssignedToExtraInfoSerializerMixin
 from taiga.projects.mixins.serializers import StatusExtraInfoSerializerMixin
 from taiga.projects.notifications.mixins import WatchedResourceSerializer
@@ -31,7 +32,7 @@ from taiga.projects.votes.mixins.serializers import VoteResourceSerializerMixin
 
 class IssueListSerializer(VoteResourceSerializerMixin, WatchedResourceSerializer,
                           OwnerExtraInfoSerializerMixin, AssignedToExtraInfoSerializerMixin,
-                          StatusExtraInfoSerializerMixin,
+                          StatusExtraInfoSerializerMixin, ProjectExtraInfoSerializerMixin,
                           TaggedInProjectResourceSerializer, serializers.LightSerializer):
     id = Field()
     ref = Field()

--- a/taiga/projects/milestones/serializers.py
+++ b/taiga/projects/milestones/serializers.py
@@ -20,9 +20,12 @@ from taiga.base.api import serializers
 from taiga.base.fields import Field, MethodField
 from taiga.projects.notifications.mixins import WatchedResourceSerializer
 from taiga.projects.userstories.serializers import UserStoryListSerializer
+from taiga.projects.mixins.serializers import ProjectExtraInfoSerializerMixin
 
 
-class MilestoneSerializer(WatchedResourceSerializer, serializers.LightSerializer):
+class MilestoneSerializer(WatchedResourceSerializer,
+                          ProjectExtraInfoSerializerMixin,
+                          serializers.LightSerializer):
     id = Field()
     name = Field()
     slug = Field()

--- a/taiga/projects/tasks/serializers.py
+++ b/taiga/projects/tasks/serializers.py
@@ -23,15 +23,18 @@ from taiga.base.neighbors import NeighborsSerializerMixin
 from taiga.mdrender.service import render as mdrender
 from taiga.projects.attachments.serializers import BasicAttachmentsInfoSerializerMixin
 from taiga.projects.mixins.serializers import OwnerExtraInfoSerializerMixin
+from taiga.projects.mixins.serializers import ProjectExtraInfoSerializerMixin
 from taiga.projects.mixins.serializers import AssignedToExtraInfoSerializerMixin
 from taiga.projects.mixins.serializers import StatusExtraInfoSerializerMixin
 from taiga.projects.notifications.mixins import WatchedResourceSerializer
 from taiga.projects.tagging.serializers import TaggedInProjectResourceSerializer
 from taiga.projects.votes.mixins.serializers import VoteResourceSerializerMixin
 
+
 class TaskListSerializer(VoteResourceSerializerMixin, WatchedResourceSerializer,
                          OwnerExtraInfoSerializerMixin, AssignedToExtraInfoSerializerMixin,
-                         StatusExtraInfoSerializerMixin, BasicAttachmentsInfoSerializerMixin,
+                         StatusExtraInfoSerializerMixin, ProjectExtraInfoSerializerMixin,
+                         BasicAttachmentsInfoSerializerMixin,
                          TaggedInProjectResourceSerializer, serializers.LightSerializer):
 
     id = Field()

--- a/taiga/projects/wiki/serializers.py
+++ b/taiga/projects/wiki/serializers.py
@@ -19,11 +19,15 @@
 from taiga.base.api import serializers
 from taiga.base.fields import Field, MethodField
 from taiga.projects.history import services as history_service
+from taiga.projects.mixins.serializers import ProjectExtraInfoSerializerMixin
 from taiga.projects.notifications.mixins import WatchedResourceSerializer
 from taiga.mdrender.service import render as mdrender
 
 
-class WikiPageSerializer(WatchedResourceSerializer, serializers.LightSerializer):
+class WikiPageSerializer(
+    WatchedResourceSerializer, ProjectExtraInfoSerializerMixin,
+    serializers.LightSerializer
+):
     id = Field()
     project = Field(attr="project_id")
     slug = Field()


### PR DESCRIPTION
Returning the project extra info for issues, tasks and milestones like already done for user stories.

Reasoning: 
* without the project details, no view (name) or link (slug) for the related project can be created for a search issues, tasks or milestones search over all projects.
* it is consistent with the user stories API

If this is not desired, please give a hint for a preferred implementation (e.g. special param or a different API endpoint to use a different serializer).