### PR TITLE
Extend order_by_fields

### DIFF
--- a/taiga/projects/issues/api.py
+++ b/taiga/projects/issues/api.py
@@ -67,6 +67,7 @@ class IssueViewSet(OCCResourceMixin, VotedResourceMixin, HistoryResourceMixin, W
                      "project__slug",
                      "status__is_closed")
     order_by_fields = ("type",
+                       "project",
                        "status",
                        "severity",
                        "priority",

--- a/taiga/projects/milestones/api.py
+++ b/taiga/projects/milestones/api.py
@@ -58,6 +58,12 @@ class MilestoneViewSet(HistoryResourceMixin, WatchedResourceMixin,
         "project__slug",
         "closed"
     )
+    order_by_fields = ("project",
+                       "name",
+                       "estimated_start",
+                       "estimated_finish",
+                       "closed",
+                       "created_date")
     queryset = models.Milestone.objects.all()
 
     def create(self, request, *args, **kwargs):

--- a/taiga/projects/tasks/api.py
+++ b/taiga/projects/tasks/api.py
@@ -67,6 +67,14 @@ class TaskViewSet(OCCResourceMixin, VotedResourceMixin, HistoryResourceMixin, Wa
                      "project",
                      "project__slug",
                      "status__is_closed"]
+    order_by_fields = ("project",
+                       "milestone",
+                       "status",
+                       "created_date",
+                       "modified_date",
+                       "assigned_to",
+                       "subject",
+                       "total_voters")
 
     def get_serializer_class(self, *args, **kwargs):
         if self.action in ["retrieve", "by_ref"]:

--- a/taiga/projects/userstories/api.py
+++ b/taiga/projects/userstories/api.py
@@ -84,6 +84,13 @@ class UserStoryViewSet(OCCResourceMixin, VotedResourceMixin, HistoryResourceMixi
                        "sprint_order",
                        "kanban_order",
                        "epic_order",
+                       "project",
+                       "milestone",
+                       "status",
+                       "created_date",
+                       "modified_date",
+                       "assigned_to",
+                       "subject",
                        "total_voters"]
 
     def get_serializer_class(self, *args, **kwargs):


### PR DESCRIPTION
For extended search (and sort) capabilities, this merge requests adds order_by_fields to milestones and tasks.

Furthermore, it adds related name fields, like type__name, status__name, severity__name etc. to order_by_fields. Thus, one can sort by status "New" over multiple projects. The relations, for example, IssueStatus, already define an ordering in their Meta like "project", "order", "name", which is not desired to be changed. However, it would be really beneficial to sort based on their name over all projects.



