### PR TITLE
Add custom project key feature to Git integrations

### DIFF
--- a/taiga/hooks/bitbucket/services.py
+++ b/taiga/hooks/bitbucket/services.py
@@ -40,6 +40,11 @@ def get_or_generate_config(project):
     url = get_absolute_url(url)
     url = "%s?project=%s&key=%s" % (url, project.id, g_config["secret"])
     g_config["webhooks_url"] = url
+
+    # Use the default 'TG' project key if not defined
+    if not "project_key" in g_config:
+        g_config["project_key"] = "TG"
+
     return g_config
 
 

--- a/taiga/hooks/event_hooks.py
+++ b/taiga/hooks/event_hooks.py
@@ -232,12 +232,14 @@ class BasePushEventHook(BaseEventHook):
         if self.ignore():
             return
         data = self.get_data()
+        project_config = self.project.modules_config.config
+        project_key = project_config[self.platform_slug]["project_key"].lower()
 
         for commit in data:
             consumed_refs = []
 
             # Status changes
-            p = re.compile("tg-(\d+) +#([-\w]+)")
+            p = re.compile(project_key + "-(\d+) +#([-\w]+)")
             for m in p.finditer(commit['commit_message'].lower()):
                 ref = m.group(1)
                 status_slug = m.group(2)
@@ -251,7 +253,7 @@ class BasePushEventHook(BaseEventHook):
                 consumed_refs.append(ref)
 
             # Reference on commit
-            p = re.compile("tg-(\d+)")
+            p = re.compile(project_key + "-(\d+)")
             for m in p.finditer(commit['commit_message'].lower()):
                 ref = m.group(1)
                 if ref in consumed_refs:

--- a/taiga/hooks/github/services.py
+++ b/taiga/hooks/github/services.py
@@ -35,4 +35,9 @@ def get_or_generate_config(project):
     url = get_absolute_url(url)
     url = "%s?project=%s" % (url, project.id)
     g_config["webhooks_url"] = url
+
+    # Use the default 'TG' project key if not defined
+    if not "project_key" in g_config:
+        g_config["project_key"] = "TG"
+
     return g_config

--- a/taiga/hooks/gitlab/services.py
+++ b/taiga/hooks/gitlab/services.py
@@ -39,4 +39,9 @@ def get_or_generate_config(project):
     url = get_absolute_url(url)
     url = "{}?project={}&key={}".format(url, project.id, g_config["secret"])
     g_config["webhooks_url"] = url
+
+    # Use the default 'TG' project key if not defined
+    if not "project_key" in g_config:
+        g_config["project_key"] = "TG"
+
     return g_config

--- a/taiga/hooks/gogs/services.py
+++ b/taiga/hooks/gogs/services.py
@@ -34,4 +34,9 @@ def get_or_generate_config(project):
     url = get_absolute_url(url)
     url = "%s?project=%s" % (url, project.id)
     g_config["webhooks_url"] = url
+
+    # Use the default 'TG' project key if not defined
+    if not "project_key" in g_config:
+        g_config["project_key"] = "TG"
+
     return g_config

--- a/tests/integration/test_hooks_bitbucket.py
+++ b/tests/integration/test_hooks_bitbucket.py
@@ -67,7 +67,8 @@ def test_ok_signature(client):
     project = f.ProjectFactory()
     f.ProjectModulesConfigFactory(project=project, config={
         "bitbucket": {
-            "secret": "tpnIwJDz4e"
+            "secret": "tpnIwJDz4e",
+            "project_key": "TG"
         }
     })
 
@@ -86,7 +87,8 @@ def test_ok_signature_ip_in_network(client):
     project = f.ProjectFactory()
     f.ProjectModulesConfigFactory(project=project, config={
         "bitbucket": {
-            "secret": "tpnIwJDz4e"
+            "secret": "tpnIwJDz4e",
+            "project_key": "TG"
         }
     })
 
@@ -187,7 +189,8 @@ def test_valid_local_network_ip(client):
     f.ProjectModulesConfigFactory(project=project, config={
         "bitbucket": {
             "secret": "tpnIwJDz4e",
-            "valid_origin_ips": ["192.168.1.1"]
+            "valid_origin_ips": ["192.168.1.1"],
+            "project_key": "TG"
         }
     })
 
@@ -207,7 +210,8 @@ def test_not_ip_filter(client):
     f.ProjectModulesConfigFactory(project=project, config={
         "bitbucket": {
             "secret": "tpnIwJDz4e",
-            "valid_origin_ips": []
+            "valid_origin_ips": [],
+            "project_key": "TG"
         }
     })
 
@@ -246,6 +250,12 @@ def test_push_event_epic_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.EpicStatusFactory(project=creation_status.project)
     epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -278,6 +288,12 @@ def test_push_event_issue_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -310,6 +326,12 @@ def test_push_event_task_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -342,6 +364,12 @@ def test_push_event_user_story_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.UserStoryStatusFactory(project=creation_status.project)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -373,6 +401,12 @@ def test_push_event_issue_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(issue, user=creation_status.project.owner)
     payload = {
         "actor": {
@@ -406,6 +440,12 @@ def test_push_event_task_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(task, user=creation_status.project.owner)
     payload = {
         "actor": {
@@ -439,6 +479,12 @@ def test_push_event_user_story_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(user_story, user=creation_status.project.owner)
     payload = {
         "actor": {
@@ -476,7 +522,13 @@ def test_push_event_multiple_actions(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
     issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+
     payload = {
         "actor": {
             "user": {
@@ -511,6 +563,12 @@ def test_push_event_processing_case_insensitive(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -539,6 +597,12 @@ def test_push_event_processing_case_insensitive(client):
 
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -569,6 +633,12 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
 
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -599,6 +669,12 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
 
 def test_push_event_us_bad_processing_non_existing_status(client):
     user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {
@@ -630,6 +706,12 @@ def test_push_event_us_bad_processing_non_existing_status(client):
 
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "bitbucket": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "actor": {
             "user": {

--- a/tests/integration/test_hooks_bitbucket.py
+++ b/tests/integration/test_hooks_bitbucket.py
@@ -282,6 +282,44 @@ def test_push_event_epic_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_epic_processing(client):
+    creation_status = f.EpicStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_epics"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.EpicStatusFactory(project=creation_status.project)
+    epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s    #%s   ok   bye!" % (epic.ref, new_status.slug) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(epic.project, payload)
+    ev_hook.process_event()
+    epic = Epic.objects.get(id=epic.id)
+    assert epic.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_issue_processing(client):
     creation_status = f.IssueStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
@@ -307,6 +345,44 @@ def test_push_event_issue_processing(client):
                 {
                     "commits": [
                         { "message": "test message   test   TG-%s    #%s   ok   bye!" % (issue.ref, new_status.slug) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue = Issue.objects.get(id=issue.id)
+    assert issue.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_issue_processing(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s    #%s   ok   bye!" % (issue.ref, new_status.slug) }
                     ]
                 }
             ]
@@ -358,6 +434,44 @@ def test_push_event_task_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_task_processing(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s    #%s   ok   bye!" % (task.ref, new_status.slug) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_user_story_processing(client):
     creation_status = f.UserStoryStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
@@ -383,6 +497,44 @@ def test_push_event_user_story_processing(client):
                 {
                     "commits": [
                         { "message": "test message   test   TG-%s    #%s   ok   bye!" % (user_story.ref, new_status.slug) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    user_story = UserStory.objects.get(id=user_story.id)
+    assert user_story.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_user_story_processing(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.UserStoryStatusFactory(project=creation_status.project)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s    #%s   ok   bye!" % (user_story.ref, new_status.slug) }
                     ]
                 }
             ]
@@ -435,6 +587,45 @@ def test_push_event_issue_mention(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_issue_mention(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(issue, user=creation_status.project.owner)
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s   ok   bye!" % (issue.ref) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue_history = get_history_queryset_by_model_instance(issue)
+    assert issue_history.count() == 1
+    assert issue_history[0].comment.startswith("This issue has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_task_mention(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -460,6 +651,45 @@ def test_push_event_task_mention(client):
                 {
                     "commits": [
                         { "message": "test message   test   TG-%s   ok   bye!" % (task.ref) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task_history = get_history_queryset_by_model_instance(task)
+    assert task_history.count() == 1
+    assert task_history[0].comment.startswith("This task has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_task_mention(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(task, user=creation_status.project.owner)
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s   ok   bye!" % (task.ref) }
                     ]
                 }
             ]
@@ -514,6 +744,44 @@ def test_push_event_user_story_mention(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_user_story_mention(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(user_story, user=creation_status.project.owner)
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s   ok   bye!" % (user_story.ref) }
+                    ]
+                }
+            ]
+        }
+    }
+
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    us_history = get_history_queryset_by_model_instance(user_story)
+    assert us_history.count() == 1
+    assert us_history[0].comment.startswith("This user story has been mentioned by")
+    assert len(mail.outbox) == 1
 
 
 def test_push_event_multiple_actions(client):
@@ -557,6 +825,47 @@ def test_push_event_multiple_actions(client):
     assert len(mail.outbox) == 2
 
 
+def test_push_event_custom_key_multiple_actions(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+    issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s    #%s   ok  test   CUSTOM-%s    #%s   ok  bye!" % (issue1.ref, new_status.slug, issue2.ref, new_status.slug) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook1 = event_hooks.PushEventHook(issue1.project, payload)
+    ev_hook1.process_event()
+    issue1 = Issue.objects.get(id=issue1.id)
+    issue2 = Issue.objects.get(id=issue2.id)
+    assert issue1.status.id == new_status.id
+    assert issue2.status.id == new_status.id
+    assert len(mail.outbox) == 2
+
+
 def test_push_event_processing_case_insensitive(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -581,7 +890,45 @@ def test_push_event_processing_case_insensitive(client):
             "changes": [
                 {
                     "commits": [
-                        { "message": "test message   test   TG-%s    #%s   ok   bye!" % (task.ref, new_status.slug) }
+                        { "message": "test message   test   tg-%s    #%s   ok   bye!" % (task.ref, new_status.slug) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_processing_case_insensitive(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   custom-%s    #%s   ok   bye!" % (task.ref, new_status.slug) }
                     ]
                 }
             ]
@@ -631,11 +978,11 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
     assert len(mail.outbox) == 0
 
 
-def test_push_event_task_bad_processing_non_existing_ref(client):
+def test_push_event_custom_key_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
     f.ProjectModulesConfigFactory(project=issue_status.project, config={
         "bitbucket": {
-            "project_key": "TG"
+            "project_key": "CUSTOM"
         }
     })
 
@@ -651,7 +998,7 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
             "changes": [
                 {
                     "commits": [
-                        { "message": "test message   test   TG-6666666    #%s   ok   bye!" % (issue_status.slug) }
+                        { "message": "test message   test   CUSTOM-6666666    #%s   ok   bye!" % (issue_status.slug) }
                     ]
                 }
             ]
@@ -704,6 +1051,43 @@ def test_push_event_us_bad_processing_non_existing_status(client):
     assert len(mail.outbox) == 0
 
 
+def test_push_event_custom_key_us_bad_processing_non_exiting_status(client):
+    user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s    #non-existing-slug   ok   bye!" % (user_story.ref) }
+                    ]
+                }
+            ]
+        }
+    }
+
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
     f.ProjectModulesConfigFactory(project=issue.project, config={
@@ -725,6 +1109,42 @@ def test_push_event_bad_processing_non_existing_status(client):
                 {
                     "commits": [
                         { "message": "test message   test   TG-%s    #non-existing-slug   ok   bye!" % (issue.ref) }
+                    ]
+                }
+            ]
+        }
+    }
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
+def test_push_event_custom_key_bad_processing_non_existing_status(client):
+    issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "bitbucket": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "actor": {
+            "user": {
+                "uuid": "{ce1054cd-3f43-49dc-8aea-d3085ee7ec9b}",
+                "username": "test-user",
+                "links": {"html": {"href": "http://bitbucket.com/test-user"}}
+            }
+        },
+        "push": {
+            "changes": [
+                {
+                    "commits": [
+                        { "message": "test message   test   CUSTOM-%s    #non-existing-slug   ok   bye!" % (issue.ref) }
                     ]
                 }
             ]

--- a/tests/integration/test_hooks_github.py
+++ b/tests/integration/test_hooks_github.py
@@ -151,6 +151,32 @@ def test_push_event_epic_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_epic_processing(client):
+    creation_status = f.EpicStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_epics"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.EpicStatusFactory(project=creation_status.project)
+    epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s    #%s   ok
+            bye!
+        """ % (epic.ref, new_status.slug)},
+    ]}
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(epic.project, payload)
+    ev_hook.process_event()
+    epic = Epic.objects.get(id=epic.id)
+    assert epic.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_issue_processing(client):
     creation_status = f.IssueStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
@@ -166,6 +192,32 @@ def test_push_event_issue_processing(client):
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #%s   ok
+            bye!
+        """ % (issue.ref, new_status.slug)},
+    ]}
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue = Issue.objects.get(id=issue.id)
+    assert issue.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_issue_processing(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s    #%s   ok
             bye!
         """ % (issue.ref, new_status.slug)},
     ]}
@@ -203,6 +255,32 @@ def test_push_event_task_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_task_processing(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s    #%s   ok
+            bye!
+        """ % (task.ref, new_status.slug)},
+    ]}
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_user_story_processing(client):
     creation_status = f.UserStoryStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
@@ -218,6 +296,33 @@ def test_push_event_user_story_processing(client):
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #%s   ok
+            bye!
+        """ % (user_story.ref, new_status.slug)},
+    ]}
+
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    user_story = UserStory.objects.get(id=user_story.id)
+    assert user_story.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_user_story_processing(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.UserStoryStatusFactory(project=creation_status.project)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s    #%s   ok
             bye!
         """ % (user_story.ref, new_status.slug)},
     ]}
@@ -257,6 +362,33 @@ def test_push_event_issue_mention(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_issue_mention(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(issue, user=creation_status.project.owner)
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s   ok
+            bye!
+        """ % (issue.ref)},
+    ]}
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue_history = get_history_queryset_by_model_instance(issue)
+    assert issue_history.count() == 1
+    assert issue_history[0].comment.startswith("This issue has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_task_mention(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -284,6 +416,33 @@ def test_push_event_task_mention(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_task_mention(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(task, user=creation_status.project.owner)
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s   ok
+            bye!
+        """ % (task.ref)},
+    ]}
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task_history = get_history_queryset_by_model_instance(task)
+    assert task_history.count() == 1
+    assert task_history[0].comment.startswith("This task has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_user_story_mention(client):
     creation_status = f.UserStoryStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
@@ -299,6 +458,34 @@ def test_push_event_user_story_mention(client):
     payload = {"commits": [
         {"message": """test message
             test   TG-%s   ok
+            bye!
+        """ % (user_story.ref)},
+    ]}
+
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    us_history = get_history_queryset_by_model_instance(user_story)
+    assert us_history.count() == 1
+    assert us_history[0].comment.startswith("This user story has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_user_story_mention(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(user_story, user=creation_status.project.owner)
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s   ok
             bye!
         """ % (user_story.ref)},
     ]}
@@ -342,6 +529,36 @@ def test_push_event_multiple_actions(client):
     assert len(mail.outbox) == 2
 
 
+def test_push_event_custom_key_multiple_actions(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+    issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s    #%s   ok
+            test   CUSTOM-%s    #%s   ok
+            bye!
+        """ % (issue1.ref, new_status.slug, issue2.ref, new_status.slug)},
+    ]}
+    mail.outbox = []
+    ev_hook1 = event_hooks.PushEventHook(issue1.project, payload)
+    ev_hook1.process_event()
+    issue1 = Issue.objects.get(id=issue1.id)
+    issue2 = Issue.objects.get(id=issue2.id)
+    assert issue1.status.id == new_status.id
+    assert issue2.status.id == new_status.id
+    assert len(mail.outbox) == 2
+
+
 def test_push_event_processing_case_insensitive(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -368,6 +585,32 @@ def test_push_event_processing_case_insensitive(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_processing_case_insensitive(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   custom-%s    #%s   ok
+            bye!
+        """ % (task.ref, new_status.slug.upper())},
+    ]}
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
     f.ProjectModulesConfigFactory(project=issue_status.project, config={
@@ -379,6 +622,30 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
     payload = {"commits": [
         {"message": """test message
             test   TG-6666666    #%s   ok
+            bye!
+        """ % (issue_status.slug)},
+    ]}
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(issue_status.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The referenced element doesn't exist"
+    assert len(mail.outbox) == 0
+
+
+def test_push_event_custom_key_task_bad_processing_non_existing_ref(client):
+    issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-6666666    #%s   ok
             bye!
         """ % (issue_status.slug)},
     ]}
@@ -417,6 +684,31 @@ def test_push_event_us_bad_processing_non_existing_status(client):
     assert len(mail.outbox) == 0
 
 
+def test_push_event_custom_key_us_bad_processing_non_existing_status(client):
+    user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s    #non-existing-slug   ok
+            bye!
+        """ % (user_story.ref)},
+    ]}
+
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
     f.ProjectModulesConfigFactory(project=issue.project, config={
@@ -428,6 +720,31 @@ def test_push_event_bad_processing_non_existing_status(client):
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #non-existing-slug   ok
+            bye!
+        """ % (issue.ref)},
+    ]}
+
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
+def test_push_event_custom_key_bad_processing_non_existing_status(client):
+    issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "github": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {"commits": [
+        {"message": """test message
+            test   CUSTOM-%s    #non-existing-slug   ok
             bye!
         """ % (issue.ref)},
     ]}

--- a/tests/integration/test_hooks_github.py
+++ b/tests/integration/test_hooks_github.py
@@ -131,6 +131,12 @@ def test_push_event_epic_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.EpicStatusFactory(project=creation_status.project)
     epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #%s   ok
@@ -151,6 +157,12 @@ def test_push_event_issue_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #%s   ok
@@ -171,6 +183,12 @@ def test_push_event_task_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #%s   ok
@@ -191,6 +209,12 @@ def test_push_event_user_story_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.UserStoryStatusFactory(project=creation_status.project)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #%s   ok
@@ -211,6 +235,12 @@ def test_push_event_issue_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(issue, user=creation_status.project.owner)
     payload = {"commits": [
         {"message": """test message
@@ -232,6 +262,12 @@ def test_push_event_task_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(task, user=creation_status.project.owner)
     payload = {"commits": [
         {"message": """test message
@@ -253,6 +289,12 @@ def test_push_event_user_story_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(user_story, user=creation_status.project.owner)
     payload = {"commits": [
         {"message": """test message
@@ -276,7 +318,13 @@ def test_push_event_multiple_actions(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
     issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #%s   ok
@@ -300,6 +348,12 @@ def test_push_event_processing_case_insensitive(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   tg-%s    #%s   ok
@@ -316,6 +370,12 @@ def test_push_event_processing_case_insensitive(client):
 
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   TG-6666666    #%s   ok
@@ -334,6 +394,12 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
 
 def test_push_event_us_bad_processing_non_existing_status(client):
     user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #non-existing-slug   ok
@@ -353,6 +419,12 @@ def test_push_event_us_bad_processing_non_existing_status(client):
 
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "github": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {"commits": [
         {"message": """test message
             test   TG-%s    #non-existing-slug   ok

--- a/tests/integration/test_hooks_gitlab.py
+++ b/tests/integration/test_hooks_gitlab.py
@@ -481,6 +481,36 @@ def test_push_event_epic_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_epic_processing(client):
+    creation_status = f.EpicStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_epics"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.EpicStatusFactory(project=creation_status.project)
+    epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+           test   CUSTOM-%s    #%s   ok
+           bye!
+        """ % (epic.ref, new_status.slug),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(epic.project, payload)
+    ev_hook.process_event()
+    epic = Epic.objects.get(id=epic.id)
+    assert epic.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_issue_processing(client):
     creation_status = f.IssueStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
@@ -511,6 +541,36 @@ def test_push_event_issue_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_issue_processing(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+           test   CUSTOM-%s    #%s   ok
+           bye!
+        """ % (issue.ref, new_status.slug),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue = Issue.objects.get(id=issue.id)
+    assert issue.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_task_processing(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -527,6 +587,36 @@ def test_push_event_task_processing(client):
     payload["commits"] = [{
         "message": """test message
             test   TG-%s    #%s   ok
+            bye!
+        """ % (task.ref, new_status.slug),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_task_processing(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s    #%s   ok
             bye!
         """ % (task.ref, new_status.slug),
         "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
@@ -572,6 +662,37 @@ def test_push_event_user_story_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_user_story_processing(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.UserStoryStatusFactory(project=creation_status.project)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s    #%s   ok
+            bye!
+        """ % (user_story.ref, new_status.slug),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    user_story = UserStory.objects.get(id=user_story.id)
+    assert user_story.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_issue_mention(client):
     creation_status = f.IssueStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
@@ -588,6 +709,36 @@ def test_push_event_issue_mention(client):
     payload["commits"] = [{
         "message": """test message
             test   TG-%s   ok
+            bye!
+        """ % (issue.ref),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue_history = get_history_queryset_by_model_instance(issue)
+    assert issue_history.count() == 1
+    assert issue_history[0].comment.startswith("This issue has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_issue_mention(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(issue, user=creation_status.project.owner)
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s   ok
             bye!
         """ % (issue.ref),
         "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
@@ -632,6 +783,36 @@ def test_push_event_task_mention(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_task_mention(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(task, user=creation_status.project.owner)
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s   ok
+            bye!
+        """ % (task.ref),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task_history = get_history_queryset_by_model_instance(task)
+    assert task_history.count() == 1
+    assert task_history[0].comment.startswith("This task has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_user_story_mention(client):
     creation_status = f.UserStoryStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
@@ -648,6 +829,37 @@ def test_push_event_user_story_mention(client):
     payload["commits"] = [{
         "message": """test message
             test   TG-%s   ok
+            bye!
+        """ % (user_story.ref),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    us_history = get_history_queryset_by_model_instance(user_story)
+    assert us_history.count() == 1
+    assert us_history[0].comment.startswith("This user story has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_user_story_mention(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(user_story, user=creation_status.project.owner)
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s   ok
             bye!
         """ % (user_story.ref),
         "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
@@ -697,6 +909,40 @@ def test_push_event_multiple_actions(client):
     assert len(mail.outbox) == 2
 
 
+def test_push_event_custom_key_multiple_actions(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+    issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s    #%s   ok
+            test   CUSTOM-%s    #%s   ok
+            bye!
+        """ % (issue1.ref, new_status.slug, issue2.ref, new_status.slug),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+    mail.outbox = []
+    ev_hook1 = event_hooks.PushEventHook(issue1.project, payload)
+    ev_hook1.process_event()
+    issue1 = Issue.objects.get(id=issue1.id)
+    issue2 = Issue.objects.get(id=issue2.id)
+    assert issue1.status.id == new_status.id
+    assert issue2.status.id == new_status.id
+    assert len(mail.outbox) == 2
+
+
 def test_push_event_processing_case_insensitive(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -727,6 +973,36 @@ def test_push_event_processing_case_insensitive(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_processing_case_insensitive(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   custom-%s    #%s   ok
+            bye!
+        """ % (task.ref, new_status.slug.upper()),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
     f.ProjectModulesConfigFactory(project=issue_status.project, config={
@@ -739,6 +1015,34 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
     payload["commits"] = [{
         "message": """test message
             test   TG-6666666    #%s   ok
+            bye!
+        """ % (issue_status.slug),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(issue_status.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The referenced element doesn't exist"
+    assert len(mail.outbox) == 0
+
+
+def test_push_event_custom_key_task_bad_processing_non_existing_ref(client):
+    issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-6666666    #%s   ok
             bye!
         """ % (issue_status.slug),
         "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
@@ -784,6 +1088,35 @@ def test_push_event_us_bad_processing_non_existing_status(client):
     assert len(mail.outbox) == 0
 
 
+def test_push_event_us_bad_processing_non_existing_status(client):
+    user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s    #non-existing-slug   ok
+            bye!
+        """ % (user_story.ref),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
     f.ProjectModulesConfigFactory(project=issue.project, config={
@@ -796,6 +1129,35 @@ def test_push_event_bad_processing_non_existing_status(client):
     payload["commits"] = [{
         "message": """test message
             test   TG-%s    #non-existing-slug   ok
+            bye!
+        """ % (issue.ref),
+        "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+        "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+    }]
+    payload["total_commits_count"] = 1
+
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
+def test_push_event_custom_key_bad_processing_non_existing_status(client):
+    issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gitlab": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = deepcopy(push_base_payload)
+    payload["commits"] = [{
+        "message": """test message
+            test   CUSTOM-%s    #non-existing-slug   ok
             bye!
         """ % (issue.ref),
         "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",

--- a/tests/integration/test_hooks_gitlab.py
+++ b/tests/integration/test_hooks_gitlab.py
@@ -250,6 +250,7 @@ def test_ok_signature(client):
         "gitlab": {
             "secret": "tpnIwJDz4e",
             "valid_origin_ips": ["111.111.111.111"],
+            "project_key": "TG"
         }
     })
 
@@ -287,6 +288,7 @@ def test_ok_signature_ip_in_network(client):
         "gitlab": {
             "secret": "tpnIwJDz4e",
             "valid_origin_ips": ["111.111.111.0/24"],
+            "project_key": "TG"
         }
     })
 
@@ -389,6 +391,7 @@ def test_valid_local_network_ip(client):
         "gitlab": {
             "secret": "tpnIwJDz4e",
             "valid_origin_ips": ["192.168.1.1"],
+            "project_key": "TG"
         }
     })
 
@@ -409,6 +412,7 @@ def test_not_ip_filter(client):
         "gitlab": {
             "secret": "tpnIwJDz4e",
             "valid_origin_ips": [],
+            "project_key": "TG"
         }
     })
 
@@ -453,6 +457,12 @@ def test_push_event_epic_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.EpicStatusFactory(project=creation_status.project)
     epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -477,6 +487,12 @@ def test_push_event_issue_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -501,6 +517,12 @@ def test_push_event_task_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -525,6 +547,12 @@ def test_push_event_user_story_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.UserStoryStatusFactory(project=creation_status.project)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -549,6 +577,12 @@ def test_push_event_issue_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(issue, user=creation_status.project.owner)
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
@@ -573,6 +607,12 @@ def test_push_event_task_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(task, user=creation_status.project.owner)
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
@@ -597,6 +637,12 @@ def test_push_event_user_story_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(user_story, user=creation_status.project.owner)
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
@@ -623,7 +669,13 @@ def test_push_event_multiple_actions(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
     issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -651,6 +703,12 @@ def test_push_event_processing_case_insensitive(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -671,6 +729,12 @@ def test_push_event_processing_case_insensitive(client):
 
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -693,6 +757,12 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
 
 def test_push_event_us_bad_processing_non_existing_status(client):
     user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message
@@ -716,6 +786,12 @@ def test_push_event_us_bad_processing_non_existing_status(client):
 
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gitlab": {
+            "project_key": "TG"
+        }
+    })
+
     payload = deepcopy(push_base_payload)
     payload["commits"] = [{
         "message": """test message

--- a/tests/integration/test_hooks_gogs.py
+++ b/tests/integration/test_hooks_gogs.py
@@ -158,6 +158,42 @@ def test_push_event_epic_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_epic_processing(client):
+    creation_status = f.EpicStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_epics"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.EpicStatusFactory(project=creation_status.project)
+    epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s    #%s   ok
+                    bye!
+                """ % (epic.ref, new_status.slug),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(epic.project, payload)
+    ev_hook.process_event()
+    epic = Epic.objects.get(id=epic.id)
+    assert epic.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_issue_processing(client):
     creation_status = f.IssueStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
@@ -175,6 +211,42 @@ def test_push_event_issue_processing(client):
             {
                 "message": """test message
                     test   TG-%s    #%s   ok
+                    bye!
+                """ % (issue.ref, new_status.slug),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue = Issue.objects.get(id=issue.id)
+    assert issue.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_issue_processing(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s    #%s   ok
                     bye!
                 """ % (issue.ref, new_status.slug),
                 "author": {
@@ -230,6 +302,42 @@ def test_push_event_task_processing(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_task_processing(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s    #%s   ok
+                    bye!
+                """ % (task.ref, new_status.slug),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_user_story_processing(client):
     creation_status = f.UserStoryStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
@@ -247,6 +355,43 @@ def test_push_event_user_story_processing(client):
             {
                 "message": """test message
                     test   TG-%s    #%s   ok
+                    bye!
+                """ % (user_story.ref, new_status.slug),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    user_story = UserStory.objects.get(id=user_story.id)
+    assert user_story.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_user_story_processing(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.UserStoryStatusFactory(project=creation_status.project)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s    #%s   ok
                     bye!
                 """ % (user_story.ref, new_status.slug),
                 "author": {
@@ -304,6 +449,43 @@ def test_push_event_issue_mention(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_issue_mention(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(issue, user=creation_status.project.owner)
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s   ok
+                    bye!
+                """ % (issue.ref),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    ev_hook.process_event()
+    issue_history = get_history_queryset_by_model_instance(issue)
+    assert issue_history.count() == 1
+    assert issue_history[0].comment.startswith("This issue has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_task_mention(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -341,6 +523,43 @@ def test_push_event_task_mention(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_task_mention(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(task, user=creation_status.project.owner)
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s   ok
+                    bye!
+                """ % (task.ref),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task_history = get_history_queryset_by_model_instance(task)
+    assert task_history.count() == 1
+    assert task_history[0].comment.startswith("This task has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_user_story_mention(client):
     creation_status = f.UserStoryStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
@@ -358,6 +577,44 @@ def test_push_event_user_story_mention(client):
             {
                 "message": """test message
                     test   TG-%s   ok
+                    bye!
+                """ % (user_story.ref),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    ev_hook.process_event()
+    us_history = get_history_queryset_by_model_instance(user_story)
+    assert us_history.count() == 1
+    assert us_history[0].comment.startswith("This user story has been mentioned by")
+    assert len(mail.outbox) == 1
+
+
+def test_push_event_custom_key_user_story_mention(client):
+    creation_status = f.UserStoryStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    take_snapshot(user_story, user=creation_status.project.owner)
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s   ok
                     bye!
                 """ % (user_story.ref),
                 "author": {
@@ -419,6 +676,46 @@ def test_push_event_multiple_actions(client):
     assert len(mail.outbox) == 2
 
 
+def test_push_event_custom_key_multiple_actions(client):
+    creation_status = f.IssueStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.IssueStatusFactory(project=creation_status.project)
+    issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s    #%s   ok
+                    test   CUSTOM-%s    #%s   ok
+                    bye!
+                """ % (issue1.ref, new_status.slug, issue2.ref, new_status.slug),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+    ev_hook1 = event_hooks.PushEventHook(issue1.project, payload)
+    ev_hook1.process_event()
+    issue1 = Issue.objects.get(id=issue1.id)
+    issue2 = Issue.objects.get(id=issue2.id)
+    assert issue1.status.id == new_status.id
+    assert issue2.status.id == new_status.id
+    assert len(mail.outbox) == 2
+
+
 def test_push_event_processing_case_insensitive(client):
     creation_status = f.TaskStatusFactory()
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
@@ -455,6 +752,42 @@ def test_push_event_processing_case_insensitive(client):
     assert len(mail.outbox) == 1
 
 
+def test_push_event_custom_key_processing_case_insensitive(client):
+    creation_status = f.TaskStatusFactory()
+    role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
+    f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
+    new_status = f.TaskStatusFactory(project=creation_status.project)
+    task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   custom-%s    #%s   ok
+                    bye!
+                """ % (task.ref, new_status.slug.upper()),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+    ev_hook = event_hooks.PushEventHook(task.project, payload)
+    ev_hook.process_event()
+    task = Task.objects.get(id=task.id)
+    assert task.status.id == new_status.id
+    assert len(mail.outbox) == 1
+
+
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
     f.ProjectModulesConfigFactory(project=issue_status.project, config={
@@ -468,6 +801,40 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
             {
                 "message": """test message
                     test   TG-6666666    #%s   ok
+                    bye!
+                """ % (issue_status.slug),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(issue_status.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The referenced element doesn't exist"
+    assert len(mail.outbox) == 0
+
+
+def test_push_event_custom_key_task_bad_processing_non_existing_ref(client):
+    issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-6666666    #%s   ok
                     bye!
                 """ % (issue_status.slug),
                 "author": {
@@ -524,6 +891,41 @@ def test_push_event_us_bad_processing_non_existing_status(client):
     assert len(mail.outbox) == 0
 
 
+def test_push_event_custom_key_us_bad_processing_non_existing_status(client):
+    user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s    #non-existing-slug   ok
+                    bye!
+                """ % (user_story.ref),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(user_story.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
     f.ProjectModulesConfigFactory(project=issue.project, config={
@@ -537,6 +939,41 @@ def test_push_event_bad_processing_non_existing_status(client):
             {
                 "message": """test message
                     test   TG-%s    #non-existing-slug   ok
+                    bye!
+                """ % (issue.ref),
+                "author": {
+                    "username": "test",
+                },
+            }
+        ],
+        "repository": {
+            "html_url": "http://test-url/test/project"
+        }
+    }
+
+    mail.outbox = []
+
+    ev_hook = event_hooks.PushEventHook(issue.project, payload)
+    with pytest.raises(ActionSyntaxException) as excinfo:
+        ev_hook.process_event()
+
+    assert str(excinfo.value) == "The status doesn't exist"
+    assert len(mail.outbox) == 0
+
+
+def test_push_event_custom_key_bad_processing_non_existing_status(client):
+    issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gogs": {
+            "project_key": "CUSTOM"
+        }
+    })
+
+    payload = {
+        "commits": [
+            {
+                "message": """test message
+                    test   CUSTOM-%s    #non-existing-slug   ok
                     bye!
                 """ % (issue.ref),
                 "author": {

--- a/tests/integration/test_hooks_gogs.py
+++ b/tests/integration/test_hooks_gogs.py
@@ -61,7 +61,8 @@ def test_ok_signature(client):
     project = f.ProjectFactory()
     f.ProjectModulesConfigFactory(project=project, config={
         "gogs": {
-            "secret": "tpnIwJDz4e"
+            "secret": "tpnIwJDz4e",
+            "project_key": "TG"
         }
     })
 
@@ -127,6 +128,12 @@ def test_push_event_epic_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.EpicStatusFactory(project=creation_status.project)
     epic = f.EpicFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=epic.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {
@@ -157,6 +164,12 @@ def test_push_event_issue_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {
@@ -187,6 +200,12 @@ def test_push_event_task_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {
@@ -217,6 +236,12 @@ def test_push_event_user_story_processing(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.UserStoryStatusFactory(project=creation_status.project)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {
@@ -247,6 +272,12 @@ def test_push_event_issue_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_issues"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     issue = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(issue, user=creation_status.project.owner)
     payload = {
         "commits": [
@@ -278,6 +309,12 @@ def test_push_event_task_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_tasks"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(task, user=creation_status.project.owner)
     payload = {
         "commits": [
@@ -309,6 +346,12 @@ def test_push_event_user_story_mention(client):
     role = f.RoleFactory(project=creation_status.project, permissions=["view_us"])
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     user_story = f.UserStoryFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     take_snapshot(user_story, user=creation_status.project.owner)
     payload = {
         "commits": [
@@ -342,6 +385,12 @@ def test_push_event_multiple_actions(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.IssueStatusFactory(project=creation_status.project)
     issue1 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=issue1.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     issue2 = f.IssueFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
     payload = {
         "commits": [
@@ -376,6 +425,12 @@ def test_push_event_processing_case_insensitive(client):
     f.MembershipFactory(project=creation_status.project, role=role, user=creation_status.project.owner)
     new_status = f.TaskStatusFactory(project=creation_status.project)
     task = f.TaskFactory.create(status=creation_status, project=creation_status.project, owner=creation_status.project.owner)
+    f.ProjectModulesConfigFactory(project=task.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {
@@ -402,6 +457,12 @@ def test_push_event_processing_case_insensitive(client):
 
 def test_push_event_task_bad_processing_non_existing_ref(client):
     issue_status = f.IssueStatusFactory()
+    f.ProjectModulesConfigFactory(project=issue_status.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {
@@ -430,6 +491,12 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
 
 def test_push_event_us_bad_processing_non_existing_status(client):
     user_story = f.UserStoryFactory.create()
+    f.ProjectModulesConfigFactory(project=user_story.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {
@@ -459,6 +526,12 @@ def test_push_event_us_bad_processing_non_existing_status(client):
 
 def test_push_event_bad_processing_non_existing_status(client):
     issue = f.IssueFactory.create()
+    f.ProjectModulesConfigFactory(project=issue.project, config={
+        "gogs": {
+            "project_key": "TG"
+        }
+    })
+
     payload = {
         "commits": [
             {


### PR DESCRIPTION
This pull request is for enhancement #980 

The corresponding PR for taiga-front is [#1298](https://github.com/taigaio/taiga-front/pull/1298)

It adds the ability to define and use custom project keys to match Git commit messages in the hook. The default project_key is set to 'TG'.

<img width="1044" alt="github_push_messages" src="https://cloud.githubusercontent.com/assets/8002179/25565870/4a90ff8c-2e13-11e7-8059-5608b4951886.png">
<img width="1052" alt="bitbucket_push_messages" src="https://cloud.githubusercontent.com/assets/8002179/25565876/56e0512a-2e13-11e7-8056-54de8eea81a7.png">
<img width="1049" alt="gitlabs_push_messages" src="https://cloud.githubusercontent.com/assets/8002179/25565879/5cd90ce8-2e13-11e7-9834-f1e9f94c78e7.png">
<img width="1039" alt="gogs_push_messages" src="https://cloud.githubusercontent.com/assets/8002179/25565881/6013a652-2e13-11e7-9f4e-400568c312d2.png">

