### PR TITLE
update CairoSVG to 2.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ python-dateutil==2.6.0
 netaddr==0.7.19
 serpy==0.1.1
 psd-tools==1.4
-CairoSVG==2.0.1
+CairoSVG==2.0.3
 python-magic==0.4.13
 cryptography==1.7.1
 PyJWT==1.4.2


### PR DESCRIPTION
Hello,

Switch to last CairoSVG release.

http://cairosvg.org/news/

Thanks,

Eric

PS : Have done it on stable as there is some commits on stable that are not merged in master, or I missed something ?