### PR TITLE
Case insensitive exact email match when accepting invite

### DIFF
--- a/taiga/projects/services/invitations.py
+++ b/taiga/projects/services/invitations.py
@@ -48,6 +48,6 @@ def find_invited_user(email, default=None):
     User = apps.get_model(settings.AUTH_USER_MODEL)
 
     try:
-        return User.objects.get(email=email)
+        return User.objects.get(email__iexact=email)
     except User.DoesNotExist:
         return default


### PR DESCRIPTION
This small change allows new invites to be sent to invited.person@example.com and accepted by Invited.Person@example.com.