### PR TITLE
Add snapshot migration for userstories

### DIFF
--- a/taiga/projects/userstories/serializers.py
+++ b/taiga/projects/userstories/serializers.py
@@ -90,7 +90,16 @@ class UserStoryListSerializer(ProjectExtraInfoSerializerMixin,
 
         :return: User queryset object representing the assigned users
         """
-        return [user.id for user in obj.assigned_users.all()]
+        if not obj.assigned_to:
+            return set([user.id for user in obj.assigned_users.all()])
+
+        assigned_users = [user.id for user in obj.assigned_users.all()] + \
+                         [obj.assigned_to.id]
+
+        if not assigned_users:
+            return None
+
+        return set(assigned_users)
 
     def get_epic_order(self, obj):
         include_epic_order = getattr(obj, "include_epic_order", False)

--- a/tests/integration/test_userstories.py
+++ b/tests/integration/test_userstories.py
@@ -104,7 +104,7 @@ def test_create_userstory_with_assigned_users(client):
     response = client.json.post(url, json_data)
 
     assert response.status_code == 201
-    assert response.data["assigned_users"] == [user.id, user_watcher.id]
+    assert response.data["assigned_users"] == set([user.id, user_watcher.id])
 
 
 def test_create_userstory_with_watchers(client):


### PR DESCRIPTION
The old snapshots hadn't have the 'assinged_users' attribute in their diffs. Because of that we need to add snapshot a "online" migration for userstories to avoid unnecessary history entries when there are changes in assigned_users.