### PR TITLE
Avoid unassigned activity

### DIFF
--- a/taiga/projects/history/models.py
+++ b/taiga/projects/history/models.py
@@ -180,6 +180,7 @@ class HistoryEntry(models.Model):
                 diff_in, diff_out = self.diff[key]
                 value_in = None
                 value_out = None
+
                 if diff_in:
                     value_in = ", ".join([resolve_value("users", x) for x in diff_in if x])
                 if diff_out:

--- a/taiga/projects/history/services.py
+++ b/taiga/projects/history/services.py
@@ -234,7 +234,8 @@ def migrate_userstory_diff(obj: FrozenObj) -> FrozenObj:
     # with the 'assigned to' value
     if 'assigned_users' not in obj.snapshot.keys():
         snapshot = deepcopy(obj.snapshot)
-        snapshot['assigned_users'] = [obj.snapshot['assigned_to']]
+        snapshot['assigned_users'] = [obj.snapshot['assigned_to']] \
+            if obj.snapshot['assigned_to'] else []
 
         obj = FrozenObj(obj.key, snapshot)
 


### PR DESCRIPTION
Avoid unnecessary changes from 'unassigned' to 'unassigned' with the new field.