### PR TITLE
Resolve incompatible dependencies pinning specific versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Pillow==4.1.1
 PyJWT==1.5.0
 Unidecode==0.4.20
 amqp==2.1.4
-asana==0.6.5
+asana==0.6.7
 bleach==2.0.0
 celery==4.0.2
 kombu==4.0.2
@@ -25,6 +25,7 @@ fn==0.4.3
 git+https://github.com/Xof/django-pglocks.git
 gunicorn==19.7.1
 jinja2==2.9.6
+idna==2.5
 lxml==3.8.0
 netaddr==0.7.19
 premailer==3.0.1


### PR DESCRIPTION
The new pip 10 detects incompatible versions for asana and requests.

It is solved by upgrading `asana` to the latest available patch release
and pinning `idna` version to the one required by `requests`.