### PR TITLE
Multi-logintype Support

### DIFF
--- a/taiga/auth/api.py
+++ b/taiga/auth/api.py
@@ -106,13 +106,14 @@ class AuthViewSet(viewsets.ViewSet):
         self.check_permissions(request, 'create', None)
         auth_plugins = get_auth_plugins()
 
-        login_type = request.DATA.get("type", None)
+        login_types = request.DATA.get("type", None)
         invitation_token = request.DATA.get("invitation_token", None)
 
-        if login_type in auth_plugins:
-            data = auth_plugins[login_type]['login_func'](request)
-            if invitation_token:
-                accept_invitation_by_existing_user(invitation_token, data['id'])
-            return response.Ok(data)
+        for login_type in login_types:
+            if login_type in auth_plugins:
+                data = auth_plugins[login_type]['login_func'](request)
+                if invitation_token:
+                    accept_invitation_by_existing_user(invitation_token, data['id'])
+                return response.Ok(data)
 
         raise exc.BadRequest(_("invalid login type"))

--- a/taiga/auth/api.py
+++ b/taiga/auth/api.py
@@ -106,9 +106,15 @@ class AuthViewSet(viewsets.ViewSet):
         self.check_permissions(request, 'create', None)
         auth_plugins = get_auth_plugins()
 
-        login_types = request.DATA.get("type", None)
+        login_types_raw = request.DATA.get("type", None)
         invitation_token = request.DATA.get("invitation_token", None)
-
+        
+        # Convert string to list
+        if type(login_types) is not list:
+            login_types[0] = login_types_raw
+        else:
+            login_types = login_types_raw
+          
         for login_type in login_types:
             if login_type in auth_plugins:
                 data = auth_plugins[login_type]['login_func'](request)


### PR DESCRIPTION
This is - to be clear - the start of an implementation to start a discussion. It most notably, does not catch the first type's login failure to allow the subsequent ones to be tried. More discussion to be added in the PR.

This issue was realized as I looked deeper in this plugin:
https://github.com/Monogramm/taiga-contrib-ldap-auth-ext/blob/master/taiga_contrib_ldap_auth_ext/services.py#L33

Note how the plugin must manually catch the LDAP error, then go try normal login, which is hardcoded.

This lacks the flexibility of being able to stack several possible authentication methods and plugins (for example: allowing different methods for employees - ldap - and external contractors - another custom plugin).

I would like to propose the ability to accept and ordered list of login types, and to attempt a login on each one, in order, before throwing a failure. This would be backwards compatible by converting a string to a single-entry list and continuing through the same logic.

The end result would be the ability to use multiple usernane/password backed authentication types with no hackery from the implementation of each type (as is done above).

I would be interested to hear your thoughts on this, and would continue the PR to a fully-formed feature if approved from the project admins.
