### PR TITLE
Fix apply_order_updates algorithm

### DIFF
--- a/taiga/projects/services/bulk_update_order.py
+++ b/taiga/projects/services/bulk_update_order.py
@@ -42,11 +42,6 @@ def apply_order_updates(base_orders: dict, new_orders: dict, *, remove_equal_ori
     invalid_keys = new_orders.keys() - base_orders.keys()
     [new_orders.pop(id, None) for id in invalid_keys]
 
-    # Remove the elements from new_orders contained in base_orders
-    if remove_equal_original:
-        common_keys = base_orders.keys() & new_orders.keys()
-        [new_orders.pop(id, None) for id in common_keys if new_orders[id] == base_orders[id]]
-
     # We will apply the multiple order changes by the new position order
     sorted_new_orders = [(k, v) for k, v in new_orders.items()]
     sorted_new_orders = sorted(sorted_new_orders, key=lambda e: e[1])
@@ -73,6 +68,11 @@ def apply_order_updates(base_orders: dict, new_orders: dict, *, remove_equal_ori
     # Remove not modified elements
     removing_keys = [id for id in base_orders if id not in updated_order_ids]
     [base_orders.pop(id, None) for id in removing_keys]
+
+    # Remove the elements that remains the same
+    if remove_equal_original:
+        common_keys = base_orders.keys() & original_orders.keys()
+        [base_orders.pop(id, None) for id in common_keys if original_orders[id] == base_orders[id]]
 
 
 def update_projects_order_in_bulk(bulk_data: list, field: str, user):

--- a/tests/unit/test_order_updates.py
+++ b/tests/unit/test_order_updates.py
@@ -199,16 +199,82 @@ def test_apply_order_not_include_noop():
     assert orders == {}
 
 
-def test_apply_order_does_no_generate_holes():
+def test_apply_order_put_it_first():
     orders = {
         "a": 0,
-        "b": 2,
-        "c": 1,
+        "b": 1,
+        "c": 2,
         "z": 99,
     }
     new_orders = {
-        "c": 1,
-        "z": 99,
+        "z": 0,
     }
     apply_order_updates(orders, new_orders, remove_equal_original=True)
-    assert orders == {}
+    assert orders == {
+        "z": 0,
+        "a": 1,
+        "b": 2,
+        "c": 3,
+    }
+
+
+def test_apply_order_put_it_first_with_tie():
+    orders = {
+        "a": 0,
+        "b": 0,
+        "c": 0,
+        "d": 1,
+        "z": 99,
+    }
+    new_orders = {
+        "z": 0,
+    }
+    apply_order_updates(orders, new_orders, remove_equal_original=True)
+    assert orders == {
+        "z": 0,
+        "a": 1,
+        "b": 1,
+        "c": 1,
+        "d": 2,
+    }
+
+
+def test_apply_order_refresh():
+    orders = {
+        "a": 0,
+        "b": 0,
+        "c": 0,
+        "d": 1,
+        "w": 99,
+        "z": 0,
+    }
+    new_orders = {
+        "z": 0,
+    }
+    apply_order_updates(orders, new_orders, remove_equal_original=True)
+    assert orders == {
+        "a": 1,
+        "b": 1,
+        "c": 1,
+        "d": 2,
+        "w": 100,
+    }
+
+
+def test_apply_order_maintain_new_values():
+    orders = {
+        "a": 1,
+        "b": 2,
+        "c": 3,
+        "d": 4,
+        "e": 7,
+        "f": 6,
+        "g": 7,
+    }
+    new_orders = {
+        "e": 7,
+        "g": 8,
+    }
+    expected = {"g": 8}
+    apply_order_updates(orders, new_orders, remove_equal_original=True)
+    assert expected == orders


### PR DESCRIPTION
With this pull request I solved a bug that happens when the destination order coincides with other user stories of the same column.