### PR TITLE
Add extra requirements for oauthlib

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ pytz = "*"
 raven = "==6.1.0"
 redis = "==2.10.5"
 requests = "==2.20.0"
+requests_oauthlib = "*"
 serpy = "==0.1.1"
 webcolors = "==1.7"
 CairoSVG = "==2.0.3"
@@ -39,6 +40,7 @@ Markdown = "==3.0.1"
 Pillow = "==4.1.1"
 Unidecode = "==0.4.20"
 Pygments = "==2.2.0"
+oauthlib = {extras = ["signedtoken"],version = "*"}
 
 [dev-packages]
 coverage = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "888d57920f90a3bcb3ad23268eef74f7c2951caa473cab150774fe460ac797a5"
+            "sha256": "2505838cdc4b5390130990ae63647a4447c5f146ab37ca8bf29f627091112cf7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,9 +40,9 @@
         },
         "billiard": {
             "hashes": [
-                "sha256:ed65448da5877b5558f19d2f7f11f8355ea76b3e63e1c0a6059f47cfae5f1c84"
+                "sha256:42d9a227401ac4fba892918bba0a0c409def5435c4b483267ebfe821afaaba0e"
             ],
-            "version": "==3.5.0.4"
+            "version": "==3.5.0.5"
         },
         "bleach": {
             "hashes": [
@@ -75,10 +75,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
-                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
-            "version": "==2018.10.15"
+            "version": "==2018.11.29"
         },
         "cffi": {
             "hashes": [
@@ -498,6 +498,13 @@
             "index": "pypi",
             "version": "==2.2.0"
         },
+        "pyjwt": {
+            "hashes": [
+                "sha256:00414bfef802aaecd8cc0d5258b6cb87bd8f553c2986c2c5f29b19dd5633aeb7",
+                "sha256:ddec8409c57e9d371c6006e388f91daf3b0b43bdf9fcbf99451fb7cf5ce0a86d"
+            ],
+            "version": "==1.7.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
@@ -634,10 +641,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
-                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
             ],
-            "version": "==2018.10.15"
+            "version": "==2018.11.29"
         },
         "chardet": {
             "hashes": [
@@ -707,10 +714,10 @@
         },
         "faker": {
             "hashes": [
-                "sha256:2621643b80a10b91999925cfd20f64d2b36f20bf22136bbdc749bb57d6ffe124",
-                "sha256:5ed822d31bd2d6edf10944d176d30dc9c886afdd381eefb7ba8b7aad86171646"
+                "sha256:c61a41d0dab8865b850bd00454fb11e90f3fd2a092d8bc90120d1e1c01cff906",
+                "sha256:f909ff9133ce0625ca388b6838190630ad7a593f87eaf058d872338a76241d5d"
             ],
-            "version": "==0.9.2"
+            "version": "==1.0.0"
         },
         "idna": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@
 amqp==2.3.2
 asana==0.6.7
 asn1crypto==0.24.0
-billiard==3.5.0.4
+billiard==3.5.0.5
 bleach==2.1.4
 cairocffi==0.9.0
 cairosvg==2.0.3
 celery==4.0.2
-certifi==2018.10.15
+certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.5.5
@@ -44,6 +44,7 @@ psd-tools==1.4
 psycopg2-binary==2.7.5
 pycparser==2.19
 pygments==2.2.0
+pyjwt==1.7.0
 python-dateutil==2.7.5
 python-magic==0.4.13
 pytz==2018.7


### PR DESCRIPTION
Add missing requirements which was causing a module not found error on jira importer module.

See https://oauthlib.readthedocs.io/en/latest/faq.html?highlight=signedtoken#oauth-2-serviceapplicationclient-and-oauth-1-with-rsa-sha1-signatures-say-could-not-import-jwt-what-should-i-do