### PR TITLE
 Hide the sensitive information in admin error reporting email

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -368,7 +368,7 @@ LOGGING = {
         "mail_admins": {
             "level": "ERROR",
             "filters": ["require_debug_false"],
-            "class": "django.utils.log.AdminEmailHandler",
+            "class": "taiga.base.utils.logs.CustomAdminEmailHandler",
         },
         "django.server": {
             "level": "INFO",
@@ -378,7 +378,7 @@ LOGGING = {
     },
     "loggers": {
         "django": {
-            "handlers":["null"],
+            "handlers":["null","mail_admins"],
             "propagate": True,
             "level":"INFO",
         },
@@ -393,12 +393,12 @@ LOGGING = {
             "propagate": False,
         },
         "taiga": {
-            "handlers": ["console"],
+            "handlers": ["console","mail_admins"],
             "level": "DEBUG",
             "propagate": False,
         },
         "django.server": {
-            "handlers": ["django.server"],
+            "handlers": ["django.server","mail_admins"],
             "level": "INFO",
             "propagate": False,
         }

--- a/settings/common.py
+++ b/settings/common.py
@@ -378,7 +378,7 @@ LOGGING = {
     },
     "loggers": {
         "django": {
-            "handlers":["null","mail_admins"],
+            "handlers":["null"],
             "propagate": True,
             "level":"INFO",
         },
@@ -393,12 +393,12 @@ LOGGING = {
             "propagate": False,
         },
         "taiga": {
-            "handlers": ["console","mail_admins"],
+            "handlers": ["console"],
             "level": "DEBUG",
             "propagate": False,
         },
         "django.server": {
-            "handlers": ["django.server","mail_admins"],
+            "handlers": ["django.server"],
             "level": "INFO",
             "propagate": False,
         }

--- a/taiga/base/utils/logs.py
+++ b/taiga/base/utils/logs.py
@@ -1,0 +1,49 @@
+from django.views.debug import ExceptionReporter
+from django.utils.log import AdminEmailHandler
+from django.conf import settings
+from django import template
+from copy import copy
+
+
+
+
+
+class CustomAdminEmailHandler(AdminEmailHandler):
+
+    def emit(self,record):
+
+        try:
+            request = record.request
+            subject = '%s (%s IP): %s' % (
+                record.levelname,
+                ('internal' if request.META.get('REMOTE_ADDR') in settings.INTERNAL_IPS
+                 else 'EXTERNAL'),
+                record.getMessage()
+            )
+        except Exception:
+            subject = '%s: %s' % (
+                record.levelname,
+                record.getMessage()
+            )
+            request = None
+        subject = self.format_subject(subject)
+
+        # Since we add a nicely formatted traceback on our own, create a copy
+        # of the log record without the exception data.
+        no_exc_record = copy(record)
+        no_exc_record.exc_info = None
+        no_exc_record.exc_text = None
+
+        if record.exc_info:
+            exc_info = record.exc_info
+        else:
+            exc_info = (None, record.getMessage(), None)
+
+        reporter = ExceptionReporter(request, is_email=True, *exc_info)
+
+        error_message = reporter.get_traceback_text().strip().splitlines()[1]
+
+        message = "%s\n\n%s" % (self.format(no_exc_record), error_message)
+        html_message = reporter.get_traceback_html() if self.include_html else None
+
+        self.send_mail(subject, message, fail_silently=True, html_message=html_message)

--- a/taiga/base/utils/logs.py
+++ b/taiga/base/utils/logs.py
@@ -41,7 +41,7 @@ class CustomAdminEmailHandler(AdminEmailHandler):
 
         reporter = ExceptionReporter(request, is_email=True, *exc_info)
 
-        error_message = reporter.get_traceback_text().strip().splitlines()[1]
+        error_message ="\n".join(reporter.get_traceback_text().strip().split("GET:")[0].splitlines()[-4:-1])
 
         message = "%s\n\n%s" % (self.format(no_exc_record), error_message)
         html_message = reporter.get_traceback_html() if self.include_html else None


### PR DESCRIPTION
Currently, there are too much sensitive information in the admin error reporting email(server configuration, code traceback and so on), these information are insecure to be left on the email and should be only put in the server log file. 

A email handler is added to filter out those sensitive information and leave only the error code, where(which file) the error occurred and the error messages in the email