### PR TITLE
fix: quote strings on CSV API for reports

### DIFF
--- a/taiga/projects/epics/services.py
+++ b/taiga/projects/epics/services.py
@@ -185,7 +185,9 @@ def epics_to_csv(project, queryset):
     queryset = attach_total_voters_to_queryset(queryset)
     queryset = attach_watchers_to_queryset(queryset)
 
-    writer = csv.DictWriter(csv_data, fieldnames=fieldnames)
+    writer = csv.DictWriter(csv_data, fieldnames=fieldnames,
+                            quoting=csv.QUOTE_ALL, escapechar='\\',
+                            doublequote=False, lineterminator='\n')
     writer.writeheader()
     for epic in queryset:
         epic_data = {

--- a/taiga/projects/issues/services.py
+++ b/taiga/projects/issues/services.py
@@ -131,7 +131,9 @@ def issues_to_csv(project, queryset):
     queryset = attach_total_voters_to_queryset(queryset)
     queryset = attach_watchers_to_queryset(queryset)
 
-    writer = csv.DictWriter(csv_data, fieldnames=fieldnames)
+    writer = csv.DictWriter(csv_data, fieldnames=fieldnames,
+                            quoting=csv.QUOTE_ALL, escapechar='\\',
+                            doublequote=False, lineterminator='\n')
     writer.writeheader()
     for issue in queryset:
         issue_data = {

--- a/taiga/projects/tasks/services.py
+++ b/taiga/projects/tasks/services.py
@@ -186,7 +186,9 @@ def tasks_to_csv(project, queryset):
     queryset = attach_total_voters_to_queryset(queryset)
     queryset = attach_watchers_to_queryset(queryset)
 
-    writer = csv.DictWriter(csv_data, fieldnames=fieldnames)
+    writer = csv.DictWriter(csv_data, fieldnames=fieldnames,
+                            quoting=csv.QUOTE_ALL, escapechar='\\',
+                            doublequote=False, lineterminator='\n')
     writer.writeheader()
     for task in queryset:
         task_data = {

--- a/taiga/projects/userstories/services.py
+++ b/taiga/projects/userstories/services.py
@@ -234,7 +234,9 @@ def userstories_to_csv(project, queryset):
     queryset = attach_total_voters_to_queryset(queryset)
     queryset = attach_watchers_to_queryset(queryset)
 
-    writer = csv.DictWriter(csv_data, fieldnames=fieldnames)
+    writer = csv.DictWriter(csv_data, fieldnames=fieldnames,
+                            quoting=csv.QUOTE_ALL, escapechar='\\',
+                            doublequote=False, lineterminator='\n')
     writer.writeheader()
     for us in queryset:
         row = {


### PR DESCRIPTION
Without this, an epic / story with a comma or quote ends up unparsable from the csv reports output.

Signed-off-by: Don Bowman <db@donbowman.ca>