### PR TITLE
FRONT_SITEMAP_CACHE_TIMEOUT listed twice in example

### DIFF
--- a/settings/local.py.example
+++ b/settings/local.py.example
@@ -153,7 +153,7 @@ DATABASES = {
 #########################################
 
 #STATS_ENABLED = False
-#FRONT_SITEMAP_CACHE_TIMEOUT = 60*60  # In second
+#STATS_CACHE_TIMEOUT = 60*60  # In second
 
 
 #########################################


### PR DESCRIPTION
FRONT_SITEMAP_CACHE_TIMEOUT was listed twice, should be
STATS_CACHE_TIMEOUT the second time. Propably a Copy & Paste
error.