### PR TITLE
Update pillow to v6.2.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ netaddr==0.7.19
 oauthlib[signedtoken]==3.1.0
 olefile==0.46
 packbits==0.6
-pillow==4.3.0
+pillow==6.2.0
 premailer==3.0.1
 psd-tools==1.8.27
 psycopg2-binary==2.7.5


### PR DESCRIPTION
I have tested the proposed change with python 3..7
See: https://pypi.org/project/Pillow/6.2.0/