### PR TITLE
fix: Send a different email for each admin

### DIFF
--- a/taiga/projects/contact/services.py
+++ b/taiga/projects/contact/services.py
@@ -38,8 +38,8 @@ def send_contact_email(contact_entry_id):
         "user_profile_url": resolve_front_url("user", contact_entry.user.username),
         "project_settings_url": resolve_front_url("project-admin", contact_entry.project.slug),
     }
-    users = contact_entry.project.get_users(with_admin_privileges=True).exclude(id=contact_entry.user_id)
-    addresses = ", ".join([u.email for u in users])
-    email = mail_builder.contact_notification(addresses, ctx)
-    email.extra_headers["Reply-To"] = ", ".join([contact_entry.user.email])
-    email.send()
+    admins = contact_entry.project.get_users(with_admin_privileges=True).exclude(id=contact_entry.user_id)
+    for admin in admins:
+        email = mail_builder.contact_notification(admin.email, ctx)
+        email.extra_headers["Reply-To"] = contact_entry.user.email
+        email.send()

--- a/tests/integration/test_contact.py
+++ b/tests/integration/test_contact.py
@@ -50,8 +50,8 @@ def test_member_create_comment_on_private_project(client):
     assert len(mail.outbox) == 0
     response = client.post(url, contact_data, content_type="application/json")
     assert response.status_code == 201
-    assert len(mail.outbox) == 1
-    assert set(mail.outbox[0].to[0].split(", ")) == set([project.owner.email, m2.user.email])
+    assert len(mail.outbox) == 2
+    assert set([to for out in mail.outbox for to in out.to]) == set([project.owner.email, m2.user.email])
 
 
 # Non members user cannot comment on a private project
@@ -95,8 +95,8 @@ def test_create_comment_on_public_project(client):
     assert len(mail.outbox) == 0
     response = client.post(url, contact_data, content_type="application/json")
     assert response.status_code == 201
-    assert len(mail.outbox) == 1
-    assert set(mail.outbox[0].to[0].split(", ")) == set([project.owner.email, m2.user.email])
+    assert len(mail.outbox) == 2
+    assert set([to for out in mail.outbox for to in out.to]) == set([project.owner.email, m2.user.email])
 
 
 # No user can comment on a project


### PR DESCRIPTION
It seems djmail does not support to pass a list of recipients to the underlying Django send mail function.