### PR TITLE
Require Django 1.11.28 to avoid SQL Injection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ django-picklefield==0.3.2
 django-sampledatahelper==0.4.1
 django-sites==0.9
 django-sr==0.0.4
-django==1.11.25
+django==1.11.28
 djmail==1.0.1
 docopt==0.6.2
 easy-thumbnails==2.4.1


### PR DESCRIPTION
This is related to CVE:
https://nvd.nist.gov/vuln/detail/CVE-2020-7471