### PR TITLE
checking if slug attribute exists

### DIFF
--- a/taiga/mdrender/extensions/wikilinks.py
+++ b/taiga/mdrender/extensions/wikilinks.py
@@ -54,8 +54,9 @@ class WikiLinksPattern(Pattern):
         label = m.group(2).strip()
 
         # `project` could be other object (!)
-        slug = getattr(self.project, "slug")
-        if not slug:
+        if hasattr(self.project, "slug"):
+            slug = getattr(self.project, "slug")
+        else:
             project = getattr(self.project, "project")
             slug = getattr(project, "slug")
             if not slug:


### PR DESCRIPTION
getattr raises  "AttributeError: 'xxxx' object has no attribute 'slug'" if the attribute does not exist. 
See https://docs.python.org/3/library/functions.html#getattr

I propose to check with hasattr() instead.