### PR TITLE
Fix incompatible version of celery/kombu and redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ billiard==3.6.3.0
 bleach==3.1.1
 cairocffi==1.1.0
 cairosvg==2.0.3
-celery==4.3.0
+celery==4.3.0rc1
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
@@ -33,7 +33,7 @@ html5lib==1.0.1
 idna==2.8
 importlib-metadata==1.5.0 ; python_version < '3.8'
 jinja2==2.11.1
-kombu==4.6.8
+kombu==4.3.0
 lxml==4.5.0
 markdown==3.1.1
 markupsafe==1.1.1


### PR DESCRIPTION
After our upgrade from Taiga 4 to 5 we noticed incompatible version of celery/kombu were pinned in requirements and we started receiving a lot of errors in taiga-front as notification and as emails.

We've found out the solution suggested by the maintainer to downgrade celery and kombu to the latest compatible version with redis 2: https://github.com/celery/celery/issues/5369#issuecomment-469320557