### PR TITLE
ready-for-test status is currently implying a ticket is closed. 

### DIFF
--- a/taiga/projects/fixtures/initial_project_templates.json
+++ b/taiga/projects/fixtures/initial_project_templates.json
@@ -225,7 +225,7 @@
                 "color": "#ffcc00",
                 "name": "Ready for test",
                 "order": 3,
-                "is_closed": true
+                "is_closed": false
             },
             {
                 "slug": "closed",
@@ -285,7 +285,7 @@
                 "color": "#88A65E",
                 "name": "Ready for test",
                 "order": 3,
-                "is_closed": true
+                "is_closed": false
             },
             {
                 "slug": "closed",
@@ -866,7 +866,7 @@
                 "color": "#f57900",
                 "name": "Ready for test",
                 "order": 3,
-                "is_closed": true
+                "is_closed": false
             },
             {
                 "slug": "closed",
@@ -926,7 +926,7 @@
                 "color": "#f57900",
                 "name": "Ready for test",
                 "order": 3,
-                "is_closed": true
+                "is_closed": false
             },
             {
                 "slug": "closed",


### PR DESCRIPTION
Greetings,
after so many years fighting in teams for a definition of ready and done I could not rapidly create this pull request.

**previous situation**
When moving a tasks to the column "ready for test", the task is considered as completed.
As a consequence for example User stories containing those tickets could be accounted as a progress, velocity is then distorted and other small impressions.

*with this fix*
At least for new installations this issue will be fixed. 

I considered not creating a migration for currently existing installations cause we would change the behavior in projects that perhaps are used on working in the wrong way.