### PR TITLE
Add swimlanes to export import

### DIFF
--- a/taiga/export_import/api.py
+++ b/taiga/export_import/api.py
@@ -183,6 +183,10 @@ class ProjectImporterViewSet(mixins.ImportThrottlingPolicyMixin, CreateModelMixi
             services.store.store_project_attributes_values(project_serialized.object, data,
                                                            "severities",
                                                            validators.SeverityExportValidator)
+        if "swimlanes" in data:
+            services.store.store_project_attributes_values(project_serialized.object, data,
+                                                           "swimlanes",
+                                                           validators.SwimlaneExportValidator)
 
         if ("points" in data or "issues_types" in data or
                 "issues_statuses" in data or "us_statuses" in data or

--- a/taiga/export_import/serializers/__init__.py
+++ b/taiga/export_import/serializers/__init__.py
@@ -22,6 +22,7 @@ from .serializers import TaskStatusExportSerializer
 from .serializers import IssueStatusExportSerializer
 from .serializers import PriorityExportSerializer
 from .serializers import SeverityExportSerializer
+from .serializers import SwimlaneExportSerializer
 from .serializers import IssueTypeExportSerializer
 from .serializers import RoleExportSerializer
 from .serializers import UserStoryCustomAttributeExportSerializer

--- a/taiga/export_import/serializers/serializers.py
+++ b/taiga/export_import/serializers/serializers.py
@@ -120,6 +120,11 @@ class SeverityExportSerializer(RelatedExportSerializer):
     color = Field()
 
 
+class SwimlaneExportSerializer(RelatedExportSerializer):
+    name = Field()
+    order = Field()
+
+
 class IssueTypeExportSerializer(RelatedExportSerializer):
     name = Field()
     order = Field()
@@ -263,6 +268,7 @@ class UserStoryExportSerializer(CustomAttributesValuesExportSerializerMixin,
     assigned_to = UserRelatedField()
     assigned_users = MethodField()
     status = SlugRelatedField(slug_field="name")
+    swimlane = SlugRelatedField(slug_field="name")
     milestone = SlugRelatedField(slug_field="name")
     modified_date = DateTimeField()
     created_date = DateTimeField()
@@ -477,6 +483,7 @@ class ProjectExportSerializer(WatcheableObjectLightSerializerMixin):
     issue_duedates = IssueDueDateExportSerializer(many=True)
     priorities = PriorityExportSerializer(many=True)
     severities = SeverityExportSerializer(many=True)
+    swimlanes = SwimlaneExportSerializer(many=True)
     tags_colors = Field()
     default_points = SlugRelatedField(slug_field="name")
     default_epic_status = SlugRelatedField(slug_field="name")

--- a/taiga/export_import/services/store.py
+++ b/taiga/export_import/services/store.py
@@ -84,7 +84,7 @@ def store_project(data):
             "default_issue_type", "default_epic_status",
             "memberships", "points",
             "epic_statuses", "us_statuses", "task_statuses", "issue_statuses",
-            "priorities", "severities",
+            "priorities", "severities", "swimlanes",
             "issue_types",
             "epiccustomattributes", "userstorycustomattributes",
             "taskcustomattributes", "issuecustomattributes",
@@ -798,6 +798,7 @@ def _populate_project_object(project, data):
     store_project_attributes_values(project, data, "issue_statuses", validators.IssueStatusExportValidator)
     store_project_attributes_values(project, data, "priorities", validators.PriorityExportValidator)
     store_project_attributes_values(project, data, "severities", validators.SeverityExportValidator)
+    store_project_attributes_values(project, data, "swimlanes", validators.SwimlaneExportValidator)
     store_project_attributes_values(project, data, "us_duedates", validators.UserStoryDueDateExportValidator)
     store_project_attributes_values(project, data, "task_duedates", validators.TaskDueDateExportValidator)
     store_project_attributes_values(project, data, "issue_duedates", validators.IssueDueDateExportValidator)

--- a/taiga/export_import/validators/__init__.py
+++ b/taiga/export_import/validators/__init__.py
@@ -8,6 +8,7 @@ from .validators import IssueStatusExportValidator
 from .validators import IssueDueDateExportValidator
 from .validators import PriorityExportValidator
 from .validators import SeverityExportValidator
+from .validators import SwimlaneExportValidator
 from .validators import IssueTypeExportValidator
 from .validators import RoleExportValidator
 from .validators import EpicCustomAttributeExportValidator

--- a/taiga/export_import/validators/validators.py
+++ b/taiga/export_import/validators/validators.py
@@ -104,6 +104,11 @@ class SeverityExportValidator(validators.ModelValidator):
         exclude = ('id', 'project')
 
 
+class SwimlaneExportValidator(validators.ModelValidator):
+    class Meta:
+        model = projects_models.Swimlane
+        exclude = ('id', 'project')
+
 class IssueTypeExportValidator(validators.ModelValidator):
     class Meta:
         model = projects_models.IssueType
@@ -413,6 +418,7 @@ class ProjectExportValidator(WatcheableObjectModelValidatorMixin):
     issue_statuses = IssueStatusExportValidator(many=True, required=False)
     priorities = PriorityExportValidator(many=True, required=False)
     severities = SeverityExportValidator(many=True, required=False)
+    swimlanes = SwimlaneExportValidator(many=True, required=False)
     tags_colors = JSONField(required=False)
     creation_template = serializers.SlugRelatedField(slug_field="slug", required=False)
     default_points = serializers.SlugRelatedField(slug_field="name", required=False)

--- a/taiga/export_import/validators/validators.py
+++ b/taiga/export_import/validators/validators.py
@@ -339,6 +339,7 @@ class UserStoryExportValidator(WatcheableObjectModelValidatorMixin):
     assigned_to = UserRelatedField(required=False)
     assigned_users = UserRelatedField(many=True, required=False)
     status = ProjectRelatedField(slug_field="name")
+    swimlane = ProjectRelatedField(slug_field="name", required=False)
     milestone = ProjectRelatedField(slug_field="name", required=False)
     modified_date = serializers.DateTimeField(required=False)
     generated_from_issue = ProjectRelatedField(slug_field="ref", required=False)


### PR DESCRIPTION
![](https://media.giphy.com/media/Ta7lq6ZMBOqzu/giphy-downsized.gif)

This PR adds swimlanes to export/import process

- [x] Check the code
- [x] Create swimlanes in a project (check the first one has userstories assigned)
- [x] Also, create a us without swimlane
- [x] Export the project. It works. Download the json
- [x] Import the project. It works. The new project has the same swimlanes and the imported uss have as well the first swimlane assigned
- [x] Move task 782