### PR TITLE
feat(userstory kanban) bulk_update_kanban_order allow move before one user story

### DIFF
--- a/taiga/projects/userstories/api.py
+++ b/taiga/projects/userstories/api.py
@@ -484,10 +484,17 @@ class UserStoryViewSet(AssignedUsersSignalMixin, OCCResourceMixin,
         if after_userstory_id is not None:
             after_userstory = get_object_or_404(models.UserStory, pk=after_userstory_id, project=project)
 
+        # Get before_userstory
+        before_userstory = None
+        before_userstory_id = data.get("before_userstory_id", None)
+        if before_userstory_id is not None:
+            before_userstory = get_object_or_404(models.UserStory, pk=before_userstory_id, project=project)
+
         ret = services.update_userstories_kanban_order_in_bulk(project=project,
                                                                status=status,
                                                                swimlane=swimlane,
                                                                after_userstory=after_userstory,
+                                                               before_userstory=before_userstory,
                                                                bulk_userstories=data["bulk_userstories"])
         return response.Ok(ret)
 


### PR DESCRIPTION
![](https://media.giphy.com/media/gJoiuQgJLBsaqefNCx/giphy.gif)

Now you can move user stories in the kanban after or before others. I add a new param, `before_us_id`, This param is incompatible with `after_us_id`, so you can set just one of the two in the request.

## How To Validate:

- [x] Prerequisites
  - [x] Regenerate data with sample data.
  - [x] Serve _taiga-front_ with branch "us/986/drag-before". 
- [x] Test 0: Review
  - [x] Review the code
  - [x] Review the test code to understand how it works
  - [x] Pass the tests.
- [x] Test 1: Move one us before other when filters are enabled 
  - [x] Go to Kanban of projects 4.
  - [x] For `In progress` status, the list of USs should be `#12, #25, #30, #39....` (from top to bottom).
  - [x] Filter excluding by tag `aperiam`
  - [x] Now, for `In progress` status, the list of USs should be `#25, #30, #39` (from top to bottom).
  - [x] Move US `#19` (first in `New`) before US `#25` (at the beginning of `In progress` status)
  - [x] Now, for `In progress` status, the list of USs should be `#19, #25, #30, #39` (from top to bottom).
  - [x] Remove filters
  - [x] Now, for `In progress` status, the list of USs should be `#12 #19 #25, #30, #39` (from top to bottom).
- [ ] Move [task #987](https://tree.taiga.io/project/taiganext/task/987?kanban-status=1857763) to _ready-for-qa_