### PR TITLE
Disable linter warnings for wildcard imports

### DIFF
--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -19,11 +19,11 @@
 from __future__ import absolute_import, print_function
 import os, sys
 
-from .celery import *
+from .celery import *  # noqa, pylint: disable=unused-wildcard-import
 
 try:
     print("Trying import local.py settings...", file=sys.stderr)
-    from .local import *
+    from .local import *  # noqa, pylint: disable=unused-wildcard-import
 except ImportError:
     print("Trying import development.py settings...", file=sys.stderr)
-    from .development import *
+    from .development import *  # noqa, pylint: disable=unused-wildcard-import

--- a/settings/development.py
+++ b/settings/development.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .common import *
+from .common import *  # noqa, pylint: disable=unused-wildcard-import
 
 DEBUG = True
 

--- a/settings/local.py.example
+++ b/settings/local.py.example
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .development import *
+from .development import *  # noqa, pylint: disable=unused-wildcard-import
 
 #########################################
 ## GENERIC

--- a/settings/testing.py
+++ b/settings/testing.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .development import *
+from .development import *  # noqa, pylint: disable=unused-wildcard-import
 
 CELERY_ENABLED = False
 


### PR DESCRIPTION
There are linter warnings showed for the absolute imports used in the settings package and it's a bit annoying. 