### PR TITLE
Change the rabbitmq host to configurable (read from ENV)

### DIFF
--- a/docker/config.py
+++ b/docker/config.py
@@ -81,8 +81,12 @@ CSRF_COOKIE_SECURE = os.getenv('CSRF_COOKIE_SECURE', 'True') == 'True'
 ## EVENTS
 #########################################
 EVENTS_PUSH_BACKEND = "taiga.events.backends.rabbitmq.EventsPushBackend"
+
+EVENTS_PUSH_BACKEND_URL = f"{ os.getenv('EVENTS_PUSH_BACKEND_URL') }"
+if not EVENTS_PUSH_BACKEND_URL:
+    EVENTS_PUSH_BACKEND_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@taiga-events-rabbitmq:5672/taiga"
 EVENTS_PUSH_BACKEND_OPTIONS = {
-    "url": f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@{ os.getenv('EVENTS_RABBITMQ_HOST', 'taiga-events-rabbitmq') }:5672/taiga"
+    "url": EVENTS_PUSH_BACKEND_URL
 }
 
 
@@ -92,7 +96,9 @@ EVENTS_PUSH_BACKEND_OPTIONS = {
 CELERY_ENABLED = os.getenv('CELERY_ENABLED', 'True') == 'True'
 from kombu import Queue  # noqa
 
-CELERY_BROKER_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@{ os.getenv('ASYNC_RABBITMQ_HOST', 'taiga-async-rabbitmq') }:5672/taiga"
+CELERY_BROKER_URL = f"{ os.getenv('CELERY_BROKER_URL') }"
+if not CELERY_BROKER_URL:
+    CELERY_BROKER_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@taiga-async-rabbitmq:5672/taiga"
 CELERY_RESULT_BACKEND = None # for a general installation, we don't need to store the results
 CELERY_ACCEPT_CONTENT = ['pickle', ]  # Values are 'pickle', 'json', 'msgpack' and 'yaml'
 CELERY_TASK_SERIALIZER = "pickle"

--- a/docker/config.py
+++ b/docker/config.py
@@ -82,7 +82,7 @@ CSRF_COOKIE_SECURE = os.getenv('CSRF_COOKIE_SECURE', 'True') == 'True'
 #########################################
 EVENTS_PUSH_BACKEND = "taiga.events.backends.rabbitmq.EventsPushBackend"
 EVENTS_PUSH_BACKEND_OPTIONS = {
-    "url": f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@taiga-events-rabbitmq:5672/taiga"
+    "url": f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@{ os.getenv('EVENTS_RABBITMQ_HOST', 'taiga-events-rabbitmq') }:5672/taiga"
 }
 
 
@@ -92,7 +92,7 @@ EVENTS_PUSH_BACKEND_OPTIONS = {
 CELERY_ENABLED = os.getenv('CELERY_ENABLED', 'True') == 'True'
 from kombu import Queue  # noqa
 
-CELERY_BROKER_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@taiga-async-rabbitmq:5672/taiga"
+CELERY_BROKER_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@{ os.getenv('ASYNC_RABBITMQ_HOST', 'taiga-async-rabbitmq') }:5672/taiga"
 CELERY_RESULT_BACKEND = None # for a general installation, we don't need to store the results
 CELERY_ACCEPT_CONTENT = ['pickle', ]  # Values are 'pickle', 'json', 'msgpack' and 'yaml'
 CELERY_TASK_SERIALIZER = "pickle"


### PR DESCRIPTION
The rabbitmq host in `docker/config.py` is hardcoded (`taiga-events-rabbitmq` and `taiga-async-rabbitmq`), it's OK for docker-compose, but in k8s the name may be different, such as `rabbit.mq.svc.cluster.local`. So it would be better to be open as configurable.