### PR TITLE
feat(sitemap): define sitemap page size by settings

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -596,6 +596,8 @@ WEBHOOKS_BLOCK_PRIVATE_ADDRESS = False
 # If is True /front/sitemap.xml show a valid sitemap of taiga-front client
 FRONT_SITEMAP_ENABLED = False
 FRONT_SITEMAP_CACHE_TIMEOUT = 24 * 60 * 60  # In second
+FRONT_SITEMAP_PAGE_SIZE = 25000
+
 
 EXTRA_BLOCKING_CODES = []
 

--- a/taiga/front/sitemaps/base.py
+++ b/taiga/front/sitemaps/base.py
@@ -14,10 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from django.conf import settings
 from django.contrib.sitemaps import Sitemap as DjangoSitemap
 
 
 class Sitemap(DjangoSitemap):
+    limit = settings.FRONT_SITEMAP_PAGE_SIZE
+
     def get_urls(self, page=1, site=None, protocol=None):
         urls = []
         latest_lastmod = None


### PR DESCRIPTION
![](https://media.giphy.com/media/decEtFxfWBEJy/giphy.gif)

Just set the page size for front sitemap.xml files with a new setting attribute.

To test it:
- set `FRONT_SITEMAP_PAGE_SIZE = 2`
- visit `http://localhost:8000/front/sitemap.xml` and check if there are more than two pages links for some resources.