### PR TITLE
Fix Jira import issue (user list not being filtered by selected project)

### DIFF
--- a/taiga/importers/jira/api.py
+++ b/taiga/importers/jira/api.py
@@ -64,7 +64,7 @@ class JiraImporterViewSet(viewsets.ViewSet):
 
         importer = JiraNormalImporter(request.user, url, token)
         try:
-            users = importer.list_users()
+            users = importer.list_users(project_id)
         except Exception as e:
             # common error due to modern Jira versions which are unsupported by Taiga
             raise exc.BadRequest(_("""

--- a/taiga/importers/jira/common.py
+++ b/taiga/importers/jira/common.py
@@ -185,12 +185,12 @@ class JiraImporterCommon:
 
         options['users_bindings'] = {k: resolve_user(v) for k,v in options['users_bindings'].items() if v is not None}
 
-    def list_users(self):
+    def list_users(self, project_id):
         result = []
-        projects = self._client.get('/project')
+        projects = self._client.get('/project/{}'.format(project_id))
         users = self._client.get("/user/assignable/multiProjectSearch", {
             "username": "",
-            "projectKeys": list(map(lambda x: x['key'], projects)),
+            "projectKeys": projects['key'],
             "maxResults": 1000,
         })
         for user in users:


### PR DESCRIPTION
**Issue:** 
Jira import process fails retrieving the list of users to be imported. 

**Cause:**
This happens when the Jira instance has a large amount of projects. The import is trying to get the list of users from all existing projects (instead of filtering by the project that is selected in the import wizard). 

**Fix:**
Code was modified to get the list of users based on the project that is selected in the import wizard.