### PR TITLE
Fix render markdown to html for checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.0.10 (unreleased)
 
-- ...
+- Render markdown to html for checkbox
 
 ## 6.0.9 (2021-04-13)
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,6 +13,7 @@ djmail==1.0.1
 easy-thumbnails==2.7.0
 fn==0.4.3
 gunicorn==19.9.0
+markdown-checklist==0.4.3
 netaddr==0.7.19
 premailer==3.0.1
 psd-tools>=1.8.27,<1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,10 +78,6 @@ html5lib==1.1
     # via -r requirements.in
 idna==2.8
     # via requests
-importlib-metadata==3.10.0
-    # via
-    #   cssutils
-    #   kombu
 jinja2==2.11.3
     # via django-jinja
 kombu==4.6.11
@@ -90,8 +86,12 @@ lxml==4.6.3
     # via
     #   cairosvg
     #   premailer
-markdown==3.1.1
+markdown-checklist==0.4.3
     # via -r requirements.in
+markdown==3.1.1
+    # via
+    #   -r requirements.in
+    #   markdown-checklist
 markupsafe==1.1.1
     # via jinja2
 monotonic==1.5
@@ -172,8 +172,6 @@ sqlparse==0.4.1
     # via django
 tinycss==0.4
     # via cairosvg
-typing-extensions==3.7.4.3
-    # via importlib-metadata
 unidecode==0.4.20
     # via -r requirements.in
 urllib3==1.24.3
@@ -189,9 +187,7 @@ webencodings==0.5.1
     #   bleach
     #   html5lib
 zipp==1.2.0
-    # via
-    #   -r requirements.in
-    #   importlib-metadata
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/taiga/mdrender/service.py
+++ b/taiga/mdrender/service.py
@@ -48,17 +48,19 @@ from .extensions.refresh_attachment import RefreshAttachmentExtension
 bleach.ALLOWED_TAGS += ["p", "table", "thead", "tbody", "th", "tr", "td", "h1",
                         "h2", "h3", "h4", "h5", "h6", "div", "pre", "span",
                         "hr", "dl", "dt", "dd", "sup", "img", "del", "br",
-                        "ins"]
+                        "ins", "input"]
 
 bleach.ALLOWED_STYLES.append("background")
 
 bleach.ALLOWED_ATTRIBUTES["a"] = ["href", "title", "alt", "target"]
 bleach.ALLOWED_ATTRIBUTES["img"] = ["alt", "src"]
+bleach.ALLOWED_ATTRIBUTES["input"] = ["type", "checked"]
 bleach.ALLOWED_ATTRIBUTES["*"] = ["class", "style", "id"]
 
 
 def _make_extensions_list(project=None):
-    return [AutolinkExtension(),
+    return ["markdown_checklist.extension",
+            AutolinkExtension(),
             AutomailExtension(),
             SemiSaneListExtension(),
             StrikethroughExtension(),

--- a/tests/unit/test_mdrender.py
+++ b/tests/unit/test_mdrender.py
@@ -311,3 +311,7 @@ def test_render_attachment_file(settings):
     assert result == expected_result
     assert mock.called is True
     mock.assert_called_with(dummy_project.id, 42)
+
+
+def test_render_markdown_to_html():
+    assert render(dummy_project, "- [x] test") == "<ul class=\"checklist\">\n<li><input checked type=\"checkbox\"> test</li>\n</ul>"


### PR DESCRIPTION
![](https://media.giphy.com/media/xT1XGzgkBT1IdfMbDi/giphy.gif)
This issue fix render markdown to html for checkbox in the editor.

Requirements:
- [x] move to branch in taiga-back
- [x] pip install -r requirements.txt
- [x] run up Taiga in local

How to test:
- [x] Open a US detail and update the description (in markdown) with this: - [ ] test
- [x] Click to save (in the editor). This checkbox doesn't show in the editor because there is a bug in taiga-front (they know it).
- [x] Check the response, the description_html field should be like that: 
`<ul class="checklist"> <li><input type="checkbox"> test</li> </ul>`
- [x] On a terminal, check the test with:
`DJANGO_SETTINGS_MODULE=tests.config py.test -k test_render_attachment_file`

Works!
- [x] Merge PR
