### PR TITLE
feat(on_premise newsletter): show newsletter subscription form after user email is changed

### DIFF
--- a/taiga/users/api.py
+++ b/taiga/users/api.py
@@ -285,6 +285,10 @@ class UsersViewSet(ModelCrudViewSet):
                                       old_email=old_email,
                                       new_email=new_email)
 
+        # If the user changes their email, the application will ask again if they
+        # want to subscribe to the Taiga newsletter.
+        user.storage_entries.filter(key="dont_ask_premise_newsletter").delete()
+
         return response.NoContent()
 
     @list_route(methods=["GET"])

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -240,6 +240,24 @@ def test_validate_requested_email_change_with_invalid_token(client):
     assert response.status_code == 400
 
 
+def test_validate_requested_email_change_for_anonymous_user_and_reset_onpremise_newsletter_form_subscriptions(client):
+    user = f.UserFactory.create(email="old@email.com", email_token="change_email_token", new_email="new@email.com")
+    user.storage_entries.create(key="dont_ask_premise_newsletter", value=True)
+
+    assert user.storage_entries.count() == 1
+
+    url = reverse('users-change-email')
+    data = {"email_token": "change_email_token"}
+
+    response = client.post(url, json.dumps(data), content_type="application/json")
+
+    assert response.status_code == 204
+    user.refresh_from_db()
+    assert user.email_token is None
+    assert user.new_email is None
+    assert user.email == "new@email.com"
+    assert user.storage_entries.count() == 0
+
 ##############################
 ## Delete user
 ##############################


### PR DESCRIPTION
This PR only removes the key (if exist) from the user's storage to not show the newsletter subscription form again. 

### HOW TO TEST:
- [x] Create a new user
- [x] Try to create a news project -> you can see the newsletter subscription form
- [x] In the newsletter subscription form check "don't ask me again"
- [x] Try to create a news project  -> you don't see the form
- [x] Change your user email
- [x] Try to create a news project -> you can see the newsletter subscription form again