### PR TITLE
Markdown to html for checkbox in editor

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,11 +13,11 @@ djmail==1.0.1
 easy-thumbnails==2.7.0
 fn==0.4.3
 gunicorn==19.9.0
-markdown-checklist==0.4.3
 netaddr==0.7.19
 premailer==3.0.1
 psd-tools>=1.8.27,<1.9
 psycopg2-binary==2.8.5
+pymdown-extensions==8.1.1
 python-dateutil==2.7.5
 python-magic==0.4.15
 pytz
@@ -30,7 +30,7 @@ serpy==0.1.1
 webcolors==1.9.1
 CairoSVG==2.0.3
 Django>=2.2,<3
-Markdown==3.1.1
+Markdown==3.3.4
 Pillow
 Unidecode==0.4.20
 Pygments==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,12 +86,10 @@ lxml==4.6.3
     # via
     #   cairosvg
     #   premailer
-markdown-checklist==0.4.3
-    # via -r requirements.in
-markdown==3.1.1
+markdown==3.3.4
     # via
     #   -r requirements.in
-    #   markdown-checklist
+    #   pymdown-extensions
 markupsafe==1.1.1
     # via jinja2
 monotonic==1.5
@@ -122,6 +120,8 @@ pygments==2.2.0
     # via -r requirements.in
 pyjwt==2.0.1
     # via oauthlib
+pymdown-extensions==8.1.1
+    # via -r requirements.in
 pyparsing==2.4.7
     # via packaging
 python-dateutil==2.7.5
@@ -188,6 +188,3 @@ webencodings==0.5.1
     #   html5lib
 zipp==1.2.0
     # via -r requirements.in
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/taiga/mdrender/service.py
+++ b/taiga/mdrender/service.py
@@ -48,7 +48,7 @@ from .extensions.refresh_attachment import RefreshAttachmentExtension
 bleach.ALLOWED_TAGS += ["p", "table", "thead", "tbody", "th", "tr", "td", "h1",
                         "h2", "h3", "h4", "h5", "h6", "div", "pre", "span",
                         "hr", "dl", "dt", "dd", "sup", "img", "del", "br",
-                        "ins", "input"]
+                        "ins", "input", "label"]
 
 bleach.ALLOWED_STYLES.append("background")
 
@@ -59,7 +59,7 @@ bleach.ALLOWED_ATTRIBUTES["*"] = ["class", "style", "id"]
 
 
 def _make_extensions_list(project=None):
-    return ["markdown_checklist.extension",
+    return ["pymdownx.tasklist",
             AutolinkExtension(),
             AutomailExtension(),
             SemiSaneListExtension(),
@@ -75,6 +75,16 @@ def _make_extensions_list(project=None):
             "markdown.extensions.sane_lists",
             "markdown.extensions.toc",
             "markdown.extensions.nl2br"]
+
+def _make_extension_configs():
+    return {
+        "pymdownx.tasklist": {
+            "custom_checkbox": [
+                True,
+                "Add an empty label tag after the input tag to allow for custom styling"
+            ]
+        }
+    }
 
 
 import diff_match_patch
@@ -107,7 +117,8 @@ def cache_by_sha(func):
 
 def _get_markdown(project):
     extensions = _make_extensions_list(project=project)
-    md = Markdown(extensions=extensions)
+    extension_configs = _make_extension_configs()
+    md = Markdown(extensions=extensions, extension_configs=extension_configs)
     md.extracted_data = {"mentions": [], "references": []}
     return md
 

--- a/tests/unit/test_mdrender.py
+++ b/tests/unit/test_mdrender.py
@@ -314,4 +314,4 @@ def test_render_attachment_file(settings):
 
 
 def test_render_markdown_to_html():
-    assert render(dummy_project, "- [x] test") == "<ul class=\"checklist\">\n<li><input checked type=\"checkbox\"> test</li>\n</ul>"
+    assert render(dummy_project, "- [x] test") == "<ul class=\"task-list\">\n<li class=\"task-list-item\"><label class=\"task-list-control\"><input checked type=\"checkbox\"><span class=\"task-list-indicator\"></span></label> test</li>\n</ul>"


### PR DESCRIPTION
This issue fix render markdown to html for checkbox in the editor.

Requirements:
- [x] move to branch in taiga-back
- [x] pip install -r requirements.txt
- [x] run up Taiga in local

How to test:
- [x] Open a US detail and update the description with this: - [ ] test
- [x] Click to save (in the editor).
- [x] Now checkbox appear in the description.
- [x] On a terminal, check the test with:
`DJANGO_SETTINGS_MODULE=tests.config py.test tests/unit/test_mdrender.py -k test_render_markdown_to_html`

Works!
- [x] Merge PR