### PR TITLE
Generate history entries, timeline entries and webhook requests after kanban order is updated (tg-4311, tg-4340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 6.2.0 (unreleased)
 
-- issue #4503: it allows to order issues by 'ref' field
+- Allows to order issues by 'ref' field (issue #tg-4503)
+- Generate history entries, timeline entries and webhook requests after kanban order is updated (issues #tg-4311, #tg-4340)
 
 ## 6.1.1 (2021-05-18)
 

--- a/taiga/projects/userstories/api.py
+++ b/taiga/projects/userstories/api.py
@@ -488,7 +488,8 @@ class UserStoryViewSet(AssignedUsersSignalMixin, OCCResourceMixin,
         if before_userstory_id is not None:
             before_userstory = get_object_or_404(models.UserStory, pk=before_userstory_id, project=project)
 
-        ret = services.update_userstories_kanban_order_in_bulk(project=project,
+        ret = services.update_userstories_kanban_order_in_bulk(user=request.user,
+                                                               project=project,
                                                                status=status,
                                                                swimlane=swimlane,
                                                                after_userstory=after_userstory,


### PR DESCRIPTION
![](https://media.giphy.com/media/j65yPBWIefJREVvJSs/giphy.gif)

This PR is for generating the the history entries, the timelines entries and the webhooks request (for contrib plugins and integrations) after moving stories in the kanban.

### HOW TO TEST:

- [x] Just move user stories in the kanban to check:
  - [x] New emntries in activity in the  moved user story detail page
  - [x] New entries in the project timeline
  - [x] New webhooks requests (if they are configured)
- [x] Close [tg-4311](https://tree.taiga.io/project/taiga/issue/4311) and [tg-4340](https://tree.taiga.io/project/taiga/issue/4340) 