### PR TITLE
fix(timeline): fix showing epic-related private uss on a public timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change api response from 404 to 401 when not logged in (issues #tg-4415, #tg-4301)
 - Allows to order issues by 'ref' field (issue #tg-4503)
 - Generate history entries, timeline entries and webhook requests after kanban order is updated (issues #tg-4311, #tg-4340)
+- Fix showing epic-related private uss on a public timeline (issue #tg-4291)
 
 ## 6.1.1 (2021-05-18)
 


### PR DESCRIPTION
This commit fixes the issue https://tree.taiga.io/project/taiga/issue/4291

It avoids to show, in a public timeline, private user stories that are related to a public epic. The corresponding timeline entry should be now just displayed according to the privileges of the current logged user.

![pr gif](https://media.giphy.com/media/TxVAozA3HngytEIXMR/giphy.gif)

### What to test

- [x]  Review the code

Step 1.- Create a public Project, Epic and a User Story. Link the User story to the Epic.
- [x] The user sees in the timeline an entry regarding this epic-related activity.
`User1 has related the user story # 1 public_us to the epic # 1 public_epic in public_project`

Still logged in, add another "User2" as a member of the public project (it's going to be used in step 2). 

Step 2.- Log in with "User2" and create both a private Project and a user story. Relate this user story to the previous public epic.
- [x] This user sees in the timeline two entries regarding epic-related activities.
`User1 has related the user story # 1 public_us to the epic # 1 public_epic in public_project`
`User2 has related the user story # 2 private_us to the epic # 1 public_epic in public_project`

Step 3.- Log in with the first user and review the timeline.
- [x] The user doesn't see the private-epic-related entry, being displayed just her previous public-related-us activity.
`User1 has related the user story # 1 public_us to the epic # 1 public_epic in public_project`

Step 4.- Assign a new user to the public and private project. In the private project, assign to her a role which has disabled the "view user story" privilege. Log in with this user and check the public project's timeline.
- [x] The user just sees the public-related-us entry in the public project's timeline, and not the private-related-us one.

Step 5.- Assign another user to the public and private project, assigning her a role in the private project with privileges to "view user stories". Log in with this user and check the public project's timeline.
- [x] The user can see the two related-us entries, both the public and the private one

Step 6.- Log out and browse to the public timeline as an anonymous user.
- [x]  The public-related-us entry is displayed, but not the private one.