### PR TITLE
fix(userstory filters): filter userstories by assignation for registered no-member users (tg-2533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Allows to order issues by 'ref' field (issue #tg-4503)
 - Generate history entries, timeline entries and webhook requests after kanban order is updated (issues #tg-4311, #tg-4340)
 - Fix showing epic-related private uss on a public timeline (issue #tg-4291)
+- Fix filter userstories by assignation for registered no-member users (issue #tg-2533)
 
 ## 6.1.1 (2021-05-18)
 

--- a/taiga/base/filters.py
+++ b/taiga/base/filters.py
@@ -459,25 +459,6 @@ class AssignedUsersFilter(FilterModelAssignedUsers, BaseRelatedFieldsFilter):
     filter_name = 'assigned_users'
     exclude_param_name = 'exclude_assigned_users'
 
-    def filter_user_projects(self, request):
-        membership_model = apps.get_model('projects', 'Membership')
-        if isinstance(request.user, AnonymousUser):
-            return None
-        else:
-            memberships_project_ids = membership_model.objects.filter(user=request.user).values(
-                'project_id')
-
-        return Subquery(memberships_project_ids)
-
-    def filter_queryset(self, request, queryset, view):
-        if self.filter_name in request.QUERY_PARAMS or \
-                self.exclude_param_name in request.QUERY_PARAMS:
-            projects_ids_subquery = self.filter_user_projects(request)
-            if projects_ids_subquery:
-                queryset = queryset.filter(project_id__in=projects_ids_subquery)
-
-        return super().filter_queryset(request, queryset, view)
-
     def _get_queryparams(self, params, mode=''):
         param_name = self.exclude_param_name if mode == 'exclude' else self.param_name or \
                                                                        self.filter_name


### PR DESCRIPTION
This PR just fix call to filter userstories by assignation for registered no-project-member users.

### Ho to tests

- [x] Login with some user 
- [x] Create a public project 
- [x] Add some users stories (for kanban and backlog) and assign to one o multiple users.
- [x] Filter by assigned users, you could see them in the kanban and backlog vires
- [x] Login with other user (no a project member)
- [x] Go to the created public project
- [x] Filter by assigned users (like before), you could see the same result in the kanban and backlog views

After merge, remember to move issue [tg-2533](https://tree.taiga.io/project/taiga/issue/2533) to staging and deploy the new changes.