### PR TITLE
Issue/4291/private related uss on any timeline

### DIFF
--- a/tests/integration/test_timeline.py
+++ b/tests/integration/test_timeline.py
@@ -12,7 +12,7 @@ import pytest
 
 from .. import factories
 from django.contrib.auth.models import AnonymousUser
-from taiga.timeline.service import build_project_namespace
+from taiga.timeline.service import build_project_namespace, build_user_namespace, get_timeline
 from taiga.projects.history import services as history_services
 from taiga.timeline import service
 from taiga.timeline.models import Timeline
@@ -565,60 +565,108 @@ def test_timeline_error_use_member_ids_instead_of_memberships_ids():
 
 
 def test_epic_related_uss():
-    print(Timeline.objects.all().delete())
     Timeline.objects.all().delete()
 
-    # Different privileged users to test
-    not_private_project_member = factories.UserFactory.create()
-    not_qualified_private_project_member = factories.UserFactory.create()
-    qualified_private_project_member = factories.UserFactory.create()
-    users = [AnonymousUser(),
-             not_private_project_member,
-             not_qualified_private_project_member,
-             qualified_private_project_member]
+    # Users
+    public_project_owner = factories.UserFactory.create(username="Public project's owner")
+    not_qualified_private_project_member = factories.UserFactory.create(username="Unprivileged private role member")
+    private_project_owner = factories.UserFactory.create(username="Privileged private role member")
 
-    # Public project containing a public epic, which contains a private us from a private project
+    # A public project, containing a public epic which contains a private us from a private project
     public_project = factories.ProjectFactory.create(is_private=False,
-                                                     owner=not_private_project_member,
+                                                     owner=public_project_owner,
                                                      anon_permissions=[],
                                                      public_permissions=["view_us"])
     factories.MembershipFactory.create(project=public_project, user=public_project.owner, is_admin=True)
-    public_epic = factories.EpicFactory.create(project=public_project, owner=not_private_project_member)
-    public_us = factories.UserStoryFactory.create(project=public_project)
+    public_epic = factories.EpicFactory.create(project=public_project, owner=public_project_owner)
+    public_us = factories.UserStoryFactory.create(project=public_project, owner=public_project_owner)
     related_public_us = factories.RelatedUserStory.create(epic=public_epic, user_story=public_us)
 
-    # Private project containing the private user story, which is related to the public epic from the public project
+    # A private project, containing the private user story related to the public epic from the public project
     private_project = factories.ProjectFactory.create(is_private=True,
-                                                      owner=qualified_private_project_member,
+                                                      owner=private_project_owner,
                                                       anon_permissions=[],
                                                       public_permissions=[])
-    # Private project roles
     not_qualified_role = factories.RoleFactory(project=private_project, permissions=[])
     qualified_role = factories.RoleFactory(project=private_project, permissions=["view_us"])
     factories.MembershipFactory.create(project=private_project,
                                        user=not_qualified_private_project_member,
                                        role=not_qualified_role)
     factories.MembershipFactory.create(project=private_project,
-                                       user=qualified_private_project_member,
+                                       user=private_project_owner,
                                        role=qualified_role)
-    private_us = factories.UserStoryFactory.create(project=private_project, owner=qualified_private_project_member)
+    private_us = factories.UserStoryFactory.create(project=private_project, owner=private_project_owner)
     related_private_us = factories.RelatedUserStory.create(epic=public_epic, user_story=private_us)
 
-    # Timeline objects creation
     service.register_timeline_implementation("epics.relateduserstory", "test", lambda x, extra_data=None: id(x))
     project_namespace = build_project_namespace(public_project)
+    # Timeline entries regarding the first epic-related public US, for both a user and a project namespace
     service._add_to_object_timeline(public_project, related_public_us, "create", datetime.now(), project_namespace)
+    service._add_to_object_timeline(public_project_owner, related_public_us, "create", datetime.now(),
+                                    build_user_namespace(public_project_owner))
+    # Timeline entries regarding the first epic-related private US, for both a user and a project namespace
     service._add_to_object_timeline(public_project, related_private_us, "create", datetime.now(), project_namespace)
+    service._add_to_object_timeline(private_project_owner, related_private_us, "create", datetime.now(),
+                                    build_user_namespace(private_project_owner))
 
-    timeline_counts = _helper_get_timelines_for_users(public_project, users)
-    assert timeline_counts == [0, 1, 1, 2]
+    """
+    # A list of users for the test iterations
+    #
+    # [index0] An anonymous user, who doesn't even have rights to see neither public nor private related USs.
+    # [index1] A public project's owner, who related a public US to an epic from her own public project. She just 
+    #   has privileges to see her public related USs, and is a simple registered user regarding the private project.
+    # [index2] An unprivileged private member, whose role doesn't have access to the private project's USs, 
+    #   but is able to view the related-USs from the public project's.
+    # [index3] A private project's owner, who linked her private US to an epic from the public project.
+                She has privileges to see any related USs.
+    """
+    users = [AnonymousUser(),  # [index 0]
+             public_project_owner,  # [index 1]
+             not_qualified_private_project_member,  # [index 2]
+             private_project_owner]  # [index 3]
+
+    timeline_counters = _helper_get_timelines_for_accessing_users(public_project, users)
+    assert timeline_counters['project_timelines'] == [0, 1, 1, 2]
+    assert timeline_counters['user_timelines'] == {
+        # An anonymous user verifies the number of 'epics.relateduserstory' entries in the other users timelines
+        #  She can't any epic related US on neither of [index1], [index2], or [index3] timelines
+        0: [0, 0, 0],
+        # An [index1] user verifies the number of 'epics.relateduserstory' entries in the other users timelines
+        #  She can just see the public epic related USs on her own [index1] timeline
+        1: [1, 0, 0],
+        # An [index2] user verifies the number of 'epics.relateduserstory' entries in the other users timelines
+        #  She can just see the public epic related USs on her own [index1] timeline
+        2: [1, 0, 0],
+        # An [index3] user verifies the number of 'epics.relateduserstory' entries in the other users timelines
+        #  She can see both the public epic related USs in [index1] timeline, and in her own [index3] timeline
+        3: [1, 0, 1]
+    }
 
 
-def _helper_get_timelines_for_users(public_project, users):
-    timeline_counts = []
-    for user in users:
-        timeline = service.get_project_timeline(public_project, user)
-        timeline = timeline.exclude(event_type__in=["projects.membership.create"])
-        timeline_counts.append(timeline.count())
+def _helper_get_timelines_for_accessing_users(project, users):
+    """
+    Get the number of timeline entries (of 'epics.relateduserstory' type) that the accessing users are able to see,
+    for both a given project's timeline and the user's timelines
+    :param project: the project with the epic which contains the related user stories
+    :param users: both the accessing users, and the users from which recover their (user) timelines
+    :return: Dict with counters for 'epics.relateduserstory' entries for both the (project) and (users)
+    timelines, according to the accessing users privileges
+    """
+    timeline_counts = {'project_timelines': [], 'user_timelines': {}}
+    # An anonymous user doesn't have a timeline to be recovered
+    timeline_users = list(filter(lambda au: au != AnonymousUser(), users))
+
+    for accessing_user in users:
+        project_timeline = service.get_project_timeline(project, accessing_user)
+        project_timeline = project_timeline.exclude(event_type__in=["projects.membership.create"])
+
+        timeline_counts['project_timelines'].append(project_timeline.count())
+        timeline_counts['user_timelines'][users.index(accessing_user)] = []
+
+        for user in timeline_users:
+            user_timeline = service.get_user_timeline(user, accessing_user)
+            user_timeline = user_timeline.exclude(event_type__in=["users.user.create", "projects.membership.create"])
+
+            timeline_counts['user_timelines'][users.index(accessing_user)].append(user_timeline.count())
 
     return timeline_counts


### PR DESCRIPTION
This commit fixes the issue https://tree.taiga.io/project/taiga/issue/4291

It avoids to show, in either a Project or User Timeline, private user stories that are related to a public epic. The corresponding timeline entry should be now just displayed according to the privileges of the accessing user.

![pr gif](https://media.giphy.com/media/AgV9U8V3uvrSxTvCyo/giphy.gif)

### What to test

- [x]  Review the code

#### Project timeline checks:

Step 1.- Create a public Project, Epic and a User Story. Link the User story to the Epic.
- [x] The user sees in the timeline an entry regarding this epic-related activity.
`User1 has related the user story # 1 public_us to the epic # 1 public_epic in public_project`

Still logged in, add another "User2" as a member of the public project (it's going to be used in step 2). 

Step 2.- Log in with "User2" and create both a private Project and a user story. Relate this user story to the previous public epic.
- [x] This user sees in the timeline two entries regarding epic-related activities.
`User1 has related the user story # 1 public_us to the epic # 1 public_epic in public_project`
`User2 has related the user story # 2 private_us to the epic # 1 public_epic in public_project`

Step 3.- Log in with the first user and review the timeline.
- [x] The user doesn't see the private-epic-related entry, being displayed just her previous public-related-us activity.
`User1 has related the user story # 1 public_us to the epic # 1 public_epic in public_project`

Step 4.- Assign a new user to the public and private project. In the private project, assign to her a role which has disabled the "view user story" privilege. Log in with this user and check the public project's timeline.
- [x] The user just sees the public-related-us entry in the public project's timeline, and not the private-related-us one.

Step 5.- Assign another user to the public and private project, assigning her a role in the private project with privileges to "view user stories". Log in with this user and check the public project's timeline.
- [x] The user can see the two related-us entries, both the public and the private one

Step 6.- Log out and browse to the public timeline as an anonymous user.
- [x]  The public-related-us entry is displayed, but not the private one.

#### User timeline checks:

Step 7.- Log in with the User2 (she should see every epic-related US)
Go to the public project which contains the epic, to review its timeline.
Open a new browser tab for every User that has an epic-related user story creation as an entry in the timeline (Ctrl+f "related", links from the user's icon at the beginning of each entry)
`User1 **has related the user story** #1 Public us to the epic #1 public epic in Public Project`
`User2 **has related the user story** #2 Private us to the epic #1 public epic in Public Project`

The opened tabs should look like these ones:
Tab 1: `http://localhost:9001/profile/user1`, and Tab 2: `http://localhost:9001/profile/user2`

Step 8.- Being logged as the User2, review the user's timelines in the browser's tabs:
- [x] User 2 should see a `related` entry on User1's timeline and another `related` entry in her own timeline (User2's timeline)

Step 9.- Log in as the User1 and refresh (F5) the two browser's tabs containing the User1 and User2 timelines:
- [x] User 1 should see its `related` entry on her own User1's timeline, but not the `related` entry in the User2's timeline

Step 10.-  Log in with the user used in the Step 4 (unprivileged member of the private project) and refresh the same two tabs:
- [x] This user should see the public `related` entry on User1's timeline, but not the `related` entry in the User2's timeline

Step 11.- Log in with the user used in the Step 5 (fully privileged member of the private project) and refresh the same two tabs:
- [x] This user should see both the public `related` entry on User1's timeline, and the `related` entry in the User2's timeline

Step 12.-  Log out and access as an anonymous user and refresh (F5) the same two tabs
- [x] An anonymous user should see the `related` entry on User1's timeline, but not the `related` entry in the User2's timeline



