### PR TITLE
fix(auth): deleted (inactive) users can still perform API calls (tgg-732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix showing epic-related private uss on a public timeline (issue #tg-4291)
 - Fix filter userstories by assignation for registered no-member users (issue #tg-2533)
 - New algorithm to reorder user stories in the backlog (issue #tg-62)
+- Fix wrong behaivor, deleted (inactive) users can still perform API calls (issue #tgg-732)
 
 ## 6.1.1 (2021-05-18)
 

--- a/taiga/auth/tokens.py
+++ b/taiga/auth/tokens.py
@@ -41,7 +41,10 @@ def get_user_for_token(token, scope, max_age=None):
     model_cls = get_user_model()
 
     try:
-        user = model_cls.objects.get(pk=data["user_%s_id" % (scope)])
+        user = model_cls.objects.get(
+            pk=data[f"user_{scope}_id"],
+            is_active=True
+        )
     except (model_cls.DoesNotExist, KeyError):
         raise exc.NotAuthenticated(_("Invalid token"))
     else:

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -301,6 +301,22 @@ def test_delete_self_user_remove_membership_projects(client):
     assert project.memberships.all().count() == 0
 
 
+def test_deleted_user_can_not_use_its_token(client):
+    user = f.UserFactory.create()
+    token = get_token_for_user(user, "authentication")
+
+    headers = {'HTTP_AUTHORIZATION': f'Bearer {token}'}
+    url = reverse('users-me')
+
+    response = client.get(url, **headers)
+    assert response.status_code == 200, response.data
+
+    user.cancel()
+
+    response = client.get(url, **headers)
+    assert response.status_code == 401, response.data
+
+
 ##############################
 ## Cancel account
 ##############################


### PR DESCRIPTION
![](https://media.giphy.com/media/3o6Mb4eFPlilbIHRN6/giphy.gif)

This PR prevents deleted users being able to using their token to make further authenticated API calls. 

### How to test

- [x] Login with the user in two diferent browsers.
- [x] In the first browser delete the user
- [x] In the second browser try to create a new project.