### PR TITLE
New api call to sorting attachments in bulk (tg-218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 6.3.0 (unreleased)
+## 6.2.1 (unreleased)
 
-- ...
+- Add new bulk_order_update endpoint to reorder attachments in bulk (issue #tgg-218)
 
 ## 6.2.0 (2021-06-09)
 

--- a/taiga/projects/attachments/permissions.py
+++ b/taiga/projects/attachments/permissions.py
@@ -27,6 +27,7 @@ class EpicAttachmentPermission(TaigaResourcePermission):
     create_perms = HasProjectPerm('modify_epic') | (CommentAttachmentPerm() & HasProjectPerm('comment_epic'))
     update_perms = HasProjectPerm('modify_epic') | IsAttachmentOwnerPerm()
     partial_update_perms = HasProjectPerm('modify_epic') | IsAttachmentOwnerPerm()
+    bulk_update_order_perms = HasProjectPerm('modify_epic') | IsAttachmentOwnerPerm()
     destroy_perms = HasProjectPerm('modify_epic') | IsAttachmentOwnerPerm()
     list_perms = AllowAny()
 
@@ -36,6 +37,7 @@ class UserStoryAttachmentPermission(TaigaResourcePermission):
     create_perms = HasProjectPerm('modify_us') | (CommentAttachmentPerm() & HasProjectPerm('comment_us'))
     update_perms = HasProjectPerm('modify_us') | IsAttachmentOwnerPerm()
     partial_update_perms = HasProjectPerm('modify_us') | IsAttachmentOwnerPerm()
+    bulk_update_order_perms = HasProjectPerm('modify_us') | IsAttachmentOwnerPerm()
     destroy_perms = HasProjectPerm('modify_us') | IsAttachmentOwnerPerm()
     list_perms = AllowAny()
 
@@ -45,6 +47,7 @@ class TaskAttachmentPermission(TaigaResourcePermission):
     create_perms = HasProjectPerm('modify_task') | (CommentAttachmentPerm() & HasProjectPerm('comment_task'))
     update_perms = HasProjectPerm('modify_task') | IsAttachmentOwnerPerm()
     partial_update_perms = HasProjectPerm('modify_task') | IsAttachmentOwnerPerm()
+    bulk_update_order_perms = HasProjectPerm('modify_task') | IsAttachmentOwnerPerm()
     destroy_perms = HasProjectPerm('modify_task') | IsAttachmentOwnerPerm()
     list_perms = AllowAny()
 
@@ -54,6 +57,7 @@ class IssueAttachmentPermission(TaigaResourcePermission):
     create_perms = HasProjectPerm('modify_issue') | (CommentAttachmentPerm() & HasProjectPerm('comment_issue'))
     update_perms = HasProjectPerm('modify_issue') | IsAttachmentOwnerPerm()
     partial_update_perms = HasProjectPerm('modify_issue') | IsAttachmentOwnerPerm()
+    bulk_update_order_perms = HasProjectPerm('modify_issue') | IsAttachmentOwnerPerm()
     destroy_perms = HasProjectPerm('modify_issue') | IsAttachmentOwnerPerm()
     list_perms = AllowAny()
 
@@ -63,6 +67,7 @@ class WikiAttachmentPermission(TaigaResourcePermission):
     create_perms = HasProjectPerm('modify_wiki_page') | (CommentAttachmentPerm() & HasProjectPerm('comment_wiki_page'))
     update_perms = HasProjectPerm('modify_wiki_page') | IsAttachmentOwnerPerm()
     partial_update_perms = HasProjectPerm('modify_wiki_page') | IsAttachmentOwnerPerm()
+    bulk_update_order_perms = HasProjectPerm('modify_wiki_page') | IsAttachmentOwnerPerm()
     destroy_perms = HasProjectPerm('modify_wiki_page') | IsAttachmentOwnerPerm()
     list_perms = AllowAny()
 

--- a/taiga/projects/attachments/validators.py
+++ b/taiga/projects/attachments/validators.py
@@ -5,8 +5,12 @@
 #
 # Copyright (c) 2021-present Kaleidos Ventures SL
 
+from django.utils.translation import ugettext as _
+
 from taiga.base.api import serializers
 from taiga.base.api import validators
+from taiga.base.exceptions import ValidationError
+from taiga.base.fields import ListField
 
 from . import models
 
@@ -20,3 +24,41 @@ class AttachmentValidator(validators.ModelValidator):
                   "description", "is_deprecated", "created_date",
                   "modified_date", "object_id", "order", "sha1", "from_comment")
         read_only_fields = ("owner", "created_date", "modified_date", "sha1")
+
+
+class UpdateAttachmentsOrderBulkValidator(validators.Validator):
+    content_type_id = serializers.IntegerField()
+    object_id = serializers.IntegerField()
+    after_attachment_id = serializers.IntegerField(required=False)
+    bulk_attachments = ListField(child=serializers.IntegerField(min_value=1))
+
+    def validate_after_attachment_id(self, attrs, source):
+        if (attrs.get(source, None) is not None
+                and attrs.get("content_type_id", None) is not None
+                and attrs.get("object_id", None) is not None):
+            filters = {
+                "content_type__id": attrs["content_type_id"],
+                "object_id": attrs["object_id"],
+                "id": attrs[source]
+            }
+
+            if not models.Attachment.objects.filter(**filters).exists():
+                raise ValidationError(_("Invalid attachment id to move after. The attachment must belong "
+                                        "to the same item (epic, userstory, task, issue or wiki page)."))
+
+        return attrs
+
+    def validate_bulk_attachments(self, attrs, source):
+        if (attrs.get("content_type_id", None) is not None
+                and attrs.get("object_id", None) is not None):
+            filters = {
+                "content_type__id": attrs["content_type_id"],
+                "object_id": attrs["object_id"],
+                "id__in": attrs[source]
+            }
+
+            if models.Attachment.objects.filter(**filters).count() != len(filters["id__in"]):
+                raise ValidationError(_("Invalid attachment ids. All attachments must belong to the same "
+                                        "item (epic, userstory, task, issue or wiki page)."))
+
+        return attrs

--- a/tests/integration/test_attachments.py
+++ b/tests/integration/test_attachments.py
@@ -10,6 +10,8 @@ import pytest
 from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 
+from taiga.base.utils import json
+
 from .. import factories as f
 
 pytestmark = pytest.mark.django_db
@@ -67,3 +69,188 @@ def test_create_attachment_with_long_file_name(client):
     client.login(issue1.owner)
     response = client.post(url, data)
     assert response.data["attached_file"].endswith("/"+100*"x"+".txt")
+
+
+######################################
+# Sorting attachments
+######################################
+
+def test_api_update_orders_in_bulk_succeeds_moved_to_the_begining(client):
+    #
+    # -------- |                     | --------
+    #   att1   |   MOVE: att2, att3  |   att2
+    #   att2   |   AFTER: bigining   |   att3
+    #   att3   |                     |   att1
+    #
+
+    project = f.create_project()
+    f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
+    us = f.create_userstory(project=project)
+
+    att1 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=1)
+    att2 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=2)
+    att3 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=3)
+
+    url = reverse("userstory-attachments-bulk-update-order")
+
+    data = {
+        "object_id": us.id,
+        "after_attachment_id": None,
+        "bulk_attachments": [att2.id,
+                             att3.id]
+    }
+
+    client.login(project.owner)
+
+    response = client.json.post(url, json.dumps(data))
+    assert response.status_code == 200, response.data
+
+    updated_ids = [
+        att2.id,
+        att3.id,
+        att1.id,
+    ]
+    res = (us.attachments.filter(id__in=updated_ids)
+                         .values("id", "order")
+                         .order_by("order", "id"))
+    assert response.json() == list(res)
+
+    att1.refresh_from_db()
+    att2.refresh_from_db()
+    att3.refresh_from_db()
+    assert att2.order == 1
+    assert att3.order == 2
+    assert att1.order == 3
+
+
+def test_api_update_orders_in_bulk_succeeds_moved_to_the_middle(client):
+    #
+    # -------- |                     | --------
+    #   att1   |   MOVE: att3, att1  |   att2
+    #   att2   |   AFTER: att2       |   att3
+    #   att3   |                     |   att1
+    #
+
+    project = f.create_project()
+    f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
+    us = f.create_userstory(project=project)
+
+    att1 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=1)
+    att2 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=2)
+    att3 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=3)
+
+    url = reverse("userstory-attachments-bulk-update-order")
+
+    data = {
+        "object_id": us.id,
+        "after_attachment_id": att2.id,
+        "bulk_attachments": [att3.id,
+                             att1.id]
+    }
+
+    client.login(project.owner)
+
+    response = client.json.post(url, json.dumps(data))
+    assert response.status_code == 200, response.data
+
+    updated_ids = [
+        att3.id,
+        att1.id,
+    ]
+    res = (us.attachments.filter(id__in=updated_ids)
+                         .values("id", "order")
+                         .order_by("order", "id"))
+    assert response.json() == list(res)
+
+    att1.refresh_from_db()
+    att2.refresh_from_db()
+    att3.refresh_from_db()
+    assert att2.order == 2
+    assert att3.order == 3
+    assert att1.order == 4
+
+
+def test_api_update_orders_in_bulk_invalid_object_id(client):
+    project = f.create_project()
+    f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
+    us = f.create_userstory(project=project)
+
+    att1 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=1)
+    att2 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=2)
+    att3 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=3)
+
+    url = reverse("userstory-attachments-bulk-update-order")
+
+    data = {
+        "after_attachment_id": att2.id,
+        "bulk_attachments": [att3.id,
+                             att1.id]
+    }
+
+    client.login(project.owner)
+
+    response = client.json.post(url, json.dumps(data))
+    assert response.status_code == 400, response.data
+    assert len(response.data) == 1
+    assert "object_id" in response.data
+
+    data["object_id"] = None
+
+    response = client.json.post(url, json.dumps(data))
+    assert response.status_code == 400, response.data
+    assert len(response.data) == 1
+    assert "object_id" in response.data
+
+
+def test_api_update_orders_in_bulk_invalid_attachments(client):
+    project = f.create_project()
+    f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
+    us = f.create_userstory(project=project)
+    us2 = f.create_userstory(project=project)
+
+    att1 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=1)
+    att2 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=2)
+    att3 = f.UserStoryAttachmentFactory(project=us2.project, content_object=us2, order=3)
+
+    url = reverse("userstory-attachments-bulk-update-order")
+
+    data = {
+        "object_id": us.id,
+        "after_attachment_id": att2.id,
+        "bulk_attachments": [att3.id,
+                             att1.id]
+    }
+
+    client.login(project.owner)
+
+    response = client.json.post(url, json.dumps(data))
+    assert response.status_code == 400, response.data
+    assert len(response.data) == 1
+    assert "bulk_attachments" in response.data
+
+
+def test_api_update_orders_in_bulk_invalid_after_attachment_because_object(client):
+    project = f.create_project()
+    f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
+    us = f.create_userstory(project=project)
+    us2 = f.create_userstory(project=project)
+
+    att1 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=1)
+    att2 = f.UserStoryAttachmentFactory(project=us.project, content_object=us, order=2)
+    att3 = f.UserStoryAttachmentFactory(project=us2.project, content_object=us2, order=3)
+
+    url = reverse("userstory-attachments-bulk-update-order")
+
+    data = {
+        "object_id": us.id,
+        "after_attachment_id": att3.id,
+        "bulk_attachments": [att2.id,
+                             att1.id]
+    }
+
+    client.login(project.owner)
+
+    response = client.json.post(url, json.dumps(data))
+    assert response.status_code == 400, response.data
+    assert len(response.data) == 1
+    assert "after_attachment_id" in response.data


### PR DESCRIPTION
![](https://media.giphy.com/media/l0Ex8f9qKbK5rgO2I/giphy.gif)

This PR adds 5 new api calls to reorder attachments of epics, user stories, tasks, issues and wiki pages with a single call instead of having to make multiple calls, one for each modified attachment. 

# How to test:

- [x] Use it with the front branche https://github.com/kaleidos-ventures/taiga-front/tree/issue/218%2Fattachments-sort.
- [x] Go to some Epic, add some attachments (3 or 4) and try to reorder them. (Tip: Remeber you can choose more than one file to upload at the same time.) 
- [x] Try the same with: 
    - [x] userstories
    - [x] tasks
    - [x] issues
    - [x] wikipages 

This PR should be related with another one from the front repository.  
Remember to move `tgg-218` to `staging`.  