### PR TITLE
fix(userstories): add filter to inprove performance for dashboard queries (#tg-4600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.2.1 (unreleased)
 
 - Add new bulk_order_update endpoint to reorder attachments in bulk (issue #tgg-218)
+- [Performance] User stories endpoint is too slow for dashboard queries (issue #tg-4600)
 
 ## 6.2.0 (2021-06-09)
 

--- a/taiga/projects/userstories/api.py
+++ b/taiga/projects/userstories/api.py
@@ -54,14 +54,15 @@ class UserStoryViewSet(AssignedUsersSignalMixin, OCCResourceMixin,
     queryset = models.UserStory.objects.all()
     permission_classes = (permissions.UserStoryPermission,)
     filter_backends = (base_filters.CanViewUsFilterBackend,
+                       filters.DashboardFilter,
                        filters.EpicFilter,
-                       base_filters.UserStoriesRoleFilter,
+                       filters.SwimlanesFilter,
+                       filters.UserStoryStatusesFilter,
+                       filters.UserStoriesRoleFilter,
+                       filters.AssignedUsersFilter,
                        base_filters.OwnersFilter,
                        base_filters.AssignedToFilter,
-                       base_filters.AssignedUsersFilter,
-                       base_filters.UserStoryStatusesFilter,
                        base_filters.TagsFilter,
-                       base_filters.SwimlanesFilter,
                        base_filters.WatchersFilter,
                        base_filters.QFilter,
                        base_filters.CreatedDateFilter,
@@ -337,9 +338,9 @@ class UserStoryViewSet(AssignedUsersSignalMixin, OCCResourceMixin,
         project = get_object_or_error(Project, request.user, id=project_id)
 
         filter_backends = self.get_filter_backends()
-        statuses_filter_backends = (f for f in filter_backends if f != base_filters.UserStoryStatusesFilter)
+        statuses_filter_backends = (f for f in filter_backends if f != filters.UserStoryStatusesFilter)
         assigned_to_filter_backends = (f for f in filter_backends if f != base_filters.AssignedToFilter)
-        assigned_users_filter_backends = (f for f in filter_backends if f != base_filters.AssignedUsersFilter)
+        assigned_users_filter_backends = (f for f in filter_backends if f != filters.AssignedUsersFilter)
         owners_filter_backends = (f for f in filter_backends if f != base_filters.OwnersFilter)
         epics_filter_backends = (f for f in filter_backends if f != filters.EpicFilter)
         roles_filter_backends = (f for f in filter_backends if f != base_filters.RoleFilter)

--- a/taiga/projects/userstories/filters.py
+++ b/taiga/projects/userstories/filters.py
@@ -5,10 +5,132 @@
 #
 # Copyright (c) 2021-present Kaleidos Ventures SL
 
+from django.apps import apps
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Q, OuterRef, Subquery
+from django.utils.translation import ugettext as _
+
 from taiga.base import filters
+
+
+def get_assigned_users_filter(model, value):
+    assigned_users_ids = model.objects.order_by().filter(
+        assigned_users__in=value, id=OuterRef('pk')).values('pk')
+
+    assigned_user_filter = Q(pk__in=Subquery(assigned_users_ids))
+    assigned_to_filter = Q(assigned_to__in=value)
+
+    return Q(assigned_user_filter | assigned_to_filter)
 
 
 class EpicFilter(filters.BaseRelatedFieldsFilter):
     filter_name = "epics"
     param_name = "epic"
     exclude_param_name = 'exclude_epic'
+
+
+class SwimlanesFilter(filters.BaseRelatedFieldsFilter):
+    filter_name = 'swimlane'
+    param_name = "swimnlane"
+    exclude_param_name = 'exclude_swimlane'
+
+
+class UserStoryStatusesFilter(filters.StatusesFilter):
+    def filter_queryset(self, request, queryset, view):
+        project_id = None
+        if "project" in request.QUERY_PARAMS:
+            try:
+                project_id = int(request.QUERY_PARAMS["project"])
+            except ValueError:
+                logger.error("Filtering user stories by status. Project value should be an integer: {}".format(
+                    request.QUERY_PARAMS["project"]))
+                raise exc.BadRequest(_("'project' must be an integer value."))
+
+        if project_id:
+            queryset = queryset.filter(status__project_id=project_id)
+
+        return super().filter_queryset(request, queryset, view)
+
+
+class AssignedUsersFilter(filters.BaseRelatedFieldsFilter):
+    filter_name = 'assigned_users'
+    exclude_param_name = 'exclude_assigned_users'
+
+    def _get_queryparams(self, params, mode=''):
+        param_name = self.exclude_param_name if mode == 'exclude' else self.param_name or \
+                                                                       self.filter_name
+        raw_value = params.get(param_name, None)
+        if raw_value:
+            value = self._prepare_filter_data(raw_value)
+            UserStoryModel = apps.get_model("userstories", "UserStory")
+
+            if None in value:
+                value.remove(None)
+                assigned_users_ids = UserStoryModel.objects.order_by().filter(
+                    assigned_users__isnull=True,
+                    id=OuterRef('pk')).values('pk')
+
+                assigned_user_filter_none = Q(pk__in=Subquery(assigned_users_ids))
+                assigned_to_filter_none = Q(assigned_to__isnull=True)
+
+                return (get_assigned_users_filter(UserStoryModel, value)
+                        | Q(assigned_user_filter_none, assigned_to_filter_none))
+            else:
+                return get_assigned_users_filter(UserStoryModel, value)
+
+        return None
+
+
+class UserStoriesRoleFilter(filters.BaseRelatedFieldsFilter):
+    filter_name = "role_id"
+    param_name = "role"
+    exclude_param_name = 'exclude_role'
+
+    def filter_queryset(self, request, queryset, view):
+        Membership = apps.get_model('projects', 'Membership')
+
+        operations = {
+            "filter": self._prepare_filter_query,
+            "exclude": self._prepare_exclude_query,
+        }
+
+        for mode, qs_method in operations.items():
+            query = self._get_queryparams(request.QUERY_PARAMS, mode=mode)
+            if query:
+                memberships = Membership.objects.filter(query).exclude(user__isnull=True). \
+                    values_list("user_id", flat=True)
+                if memberships:
+                    user_story_model = apps.get_model("userstories", "UserStory")
+                    queryset = queryset.filter(
+                        qs_method(Q(get_assigned_users_filter(user_story_model, memberships)))
+                    )
+
+        return filters.FilterBackend.filter_queryset(self, request, queryset, view)
+
+
+class DashboardFilter(filters.FilterBackend):
+    """
+    This filter improves performance for dashboard queries.
+    Only search in the user projects
+    """
+    filter_name = 'dashboard'
+    param_name = "dashboard"
+
+    def _filter_user_projects(self, request):
+        membership_model = apps.get_model('projects', 'Membership')
+        if isinstance(request.user, AnonymousUser):
+            return None
+        else:
+            memberships_project_ids = membership_model.objects.filter(user=request.user).values(
+                'project_id')
+
+        return Subquery(memberships_project_ids)
+
+    def filter_queryset(self, request, queryset, view):
+        if request.QUERY_PARAMS.get(self.param_name, False):
+            user_projects_ids_subquery = self._filter_user_projects(request)
+
+            if user_projects_ids_subquery:
+                queryset = queryset.filter(project_id__in=user_projects_ids_subquery)
+
+        return super().filter_queryset(request, queryset, view)


### PR DESCRIPTION
![](https://media.giphy.com/media/hRD2Bynz4dsE4faI34/giphy.gif)

This only affects instances with huge heap of data. Dashboard view load slowly because userstory endpoint spend lot of time filtering stories by assigned user. 

This PR just add a new filter for dashboard calls (`/api/v1/userstories/?dashboard=true') that will only search in those projects where the user is a member.  

(I have taken the opportunity to move specific filters to userstories module too)