### PR TITLE
Avoid logging url token changes on history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.3.0 (unreleased)
 
-- ...
+- Avoid logging in the history changes in the attachment's urls or its order (issue #tg-4247)
 
 ## 6.2.1 (2021-06-22)
 

--- a/taiga/projects/history/models.py
+++ b/taiga/projects/history/models.py
@@ -219,7 +219,7 @@ class HistoryEntry(models.Model):
                 for aid in set(tuple(oldattachs.keys()) + tuple(newattachs.keys())):
                     if aid in oldattachs and aid in newattachs:
                         changes = make_diff_from_dicts(oldattachs[aid], newattachs[aid],
-                                                       excluded_keys=("filename", "url", "thumb_url"))
+                                                       excluded_keys=("filename", "url", "thumb_url", "order"))
 
                         if changes:
                             change = {

--- a/taiga/projects/history/services.py
+++ b/taiga/projects/history/services.py
@@ -259,9 +259,34 @@ def make_diff(oldobj: FrozenObj, newobj: FrozenObj,
     first = oldobj.snapshot
     second = newobj.snapshot
 
-    diff = make_diff_from_dicts(first, second, None, excluded_keys)
+    # The object's attachments are manually handled to avoid considering changes in their URL's token as a user activity
+    #   (just when the `taiga-protected` module is enabled)
+    diff = make_diff_from_dicts(first, second, None, frozenset().union(excluded_keys, frozenset(["attachments"])))
+    attach_diffs = _make_diff_in_attachments(first, second)
+    if attach_diffs:
+        diff["attachments"] = attach_diffs
 
     return FrozenDiff(newobj.key, diff, newobj.snapshot)
+
+
+def _make_diff_in_attachments(first_snapshot, second_snapshot):
+    if "attachments" in first_snapshot:
+        old_attachments = {x["id"]: x for x in first_snapshot["attachments"]}
+        new_attachments = {x["id"]: x for x in second_snapshot["attachments"]}
+        snapshot_attachments_tuple = first_snapshot["attachments"], second_snapshot["attachments"]
+
+        for attach_id in set(tuple(old_attachments.keys()) + tuple(new_attachments.keys())):
+            if attach_id in old_attachments and attach_id in new_attachments:
+                attachments_changed = make_diff_from_dicts(old_attachments[attach_id], new_attachments[attach_id],
+                                              excluded_keys=("filename", "url", "thumb_url", "order"))
+                if attachments_changed:
+                    return snapshot_attachments_tuple
+            elif attach_id in old_attachments and attach_id not in new_attachments:
+                return snapshot_attachments_tuple
+            elif attach_id not in old_attachments and attach_id in new_attachments:
+                return snapshot_attachments_tuple
+
+    return None
 
 
 def make_diff_values(typename: str, fdiff: FrozenDiff) -> dict:


### PR DESCRIPTION
Fixes this [issue](https://tree.taiga.io/project/taiga/issue/4247#) in Taiga

When using the taiga-protected module, a Token is added to the attachment's URL. The problem is that when it gets updated, its also being logged as a blank entry in the object's activity. Although it's been fixed in front, it stills occurs when calling the back API directly.
It's also being fixed another problem, that avoids to log changes in the order of attachments.

### How to test
Prerequirements: 
- [x] Enable the taiga-protected module locally according to the [installation guide](https://docs.taiga.io/setup-production.html#install-protected). 
- [x] Verify the attachments include a TOKEN as part of its url

A. Using the browser
- [x] Create a new userstory
- [x] Add some attachments to it
- [x] Reorder some of them
- [x] Delete an attachment in the middle

NOTE: At each of the previous steps, review the new activities reflect the operations and it's not showing any blank or weird operations.

B. Using the API

- [x]  Chose an attachment (id) and call the API's endpoint to update its description writing exactly the same previous value

```
PATCH {{protocol}}://{{domain}}{{port}}{{api_url}}/userstories/attachments/14827
{
    "description": "description"
}
```
The operation shouldn't be logged in the activity or show any blank entry (because its url's token gets updated internally).