### PR TITLE
Fix the user when closing an issue from GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.3.0 (unreleased)
 
 - New Auth module, based on djangorestframework-simplejwt (history #tg-4625, issue #tgg-626))
+- Fix the user when closing an issue from Github (issue #tg-4563)
 
 ## 6.2.2 (2021-07-15)
 

--- a/taiga/hooks/github/event_hooks.py
+++ b/taiga/hooks/github/event_hooks.py
@@ -49,13 +49,14 @@ class IssuesEventHook(BaseGitHubEventHook, BaseIssueEventHook):
         description = self.payload.get('issue', {}).get('body', None)
         project_url = self.payload.get('repository', {}).get('html_url', None)
         state = self.payload.get('issue', {}).get('state', 'open')
+
         return {
             "number": self.payload.get('issue', {}).get('number', None),
             "subject": self.payload.get('issue', {}).get('title', None),
             "url": self.payload.get('issue', {}).get('html_url', None),
-            "user_id": self.payload.get('issue', {}).get('user', {}).get('id', None),
-            "user_name": self.payload.get('issue', {}).get('user', {}).get('login', None),
-            "user_url": self.payload.get('issue', {}).get('user', {}).get('html_url', None),
+            "user_id": self.payload.get('sender', {}).get('id', None),
+            "user_name": self.payload.get('sender', {}).get('login', None),
+            "user_url": self.payload.get('sender', {}).get('html_url', None),
             "description": self.replace_github_references(project_url, description),
             "status": self.close_status if state == "closed" else self.open_status,
         }


### PR DESCRIPTION
Related to this [issue](https://tree.taiga.io/project/taiga/issue/4563) in Taiga.

![](https://media.giphy.com/media/LLHkw7UnvY3Kw/giphy-downsized.gif)


### How to test

1. Review the code

The changes are rather trivial and t has already been verified with @bameda that it works properly (at least locally using Ngrok)

NOTE - It simply recovers from the payload another field instead of `user`, and according to the Github's dcoumentation any webhook should always include the new `sender` field :
https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads

2. If you agree with the changes, merge this PR and wait to be deployed on **taiga6.kaleidos.net** to fully validate it.
Then, follow this steps:

* Choose a project in Taiga and configure the github's integration
` Taiga project > Settings > Integration > Webhooks`
*  Choose a project in github and add a new Webhook pointing the previous project in Taiga
`Github project > X > Settings > Webhooks > Add webhook`
* **Create an issue** in the Github project being logged with a first user (userA).
Verify a new issue is created in the related project in Taiga, and the user who creates the issue matches.
* Create a **new comment** for the previous issue in Github using a second user (userB)
Verify the new comment exists in the linked Taiga's project and check the user who creates the comment matches
* **Close the issue** on github with the second user (userB). 
Check the issues's status changes and the user that performed the operation matches
* **Re-open the issue** on github using the second user (userB).
Check the issues's status and user that performed the operation matches

