### PR TITLE
feat(userstories): add new serializer with ref and id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 
-## 6.3.1 (unreleased)
+## 6.4.0 (unreleased)
 
-- ...
+- Serve Taiga in subpath
+- Add new serializer to userstories endpoint witn minimal info (id, ref) (issue #tg-4739)
 
 ## 6.3.0 (2021-08-10)
 
 - New Auth module, based on djangorestframework-simplejwt (history #tg-4625, issue #tgg-626))
 - Fix the user when closing an issue from Github (issue #tg-4563)
-- Serve Taiga in subpath
 
 ## 6.2.2 (2021-07-15)
 

--- a/taiga/projects/userstories/api.py
+++ b/taiga/projects/userstories/api.py
@@ -95,41 +95,48 @@ class UserStoryViewSet(AssignedUsersSignalMixin, OCCResourceMixin,
         if self.action in ["retrieve", "by_ref"]:
             return serializers.UserStoryNeighborsSerializer
 
-        if self.action == "list" and self.request.QUERY_PARAMS.get('dashboard', False):
-            return serializers.UserStoryLightSerializer
-
         if self.action == "list":
+            if self.request.QUERY_PARAMS.get('dashboard', False):
+                return serializers.UserStoryLightSerializer
+            elif self.request.QUERY_PARAMS.get('only_ref', False):
+                return serializers.UserStoryOnlyRefSerializer
             return serializers.UserStoryListSerializer
 
         return serializers.UserStorySerializer
 
     def get_queryset(self):
         qs = super().get_queryset()
+
+        if self.request.QUERY_PARAMS.get('only_ref', False):
+            return qs
+
         qs = qs.select_related("project",
                                "status",
                                "assigned_to")
 
-        if not self.request.QUERY_PARAMS.get('dashboard', False):
-            qs = qs.select_related("milestone",
-                                   "owner",
-                                   "generated_from_issue",
-                                   "generated_from_task")
+        if self.request.QUERY_PARAMS.get('dashboard', False):
+            return qs
 
-            qs = qs.prefetch_related("assigned_users")
-            include_attachments = "include_attachments" in self.request.QUERY_PARAMS
-            include_tasks = "include_tasks" in self.request.QUERY_PARAMS
+        qs = qs.select_related("milestone",
+                               "owner",
+                               "generated_from_issue",
+                               "generated_from_task")
 
-            epic_id = self.request.QUERY_PARAMS.get("epic", None)
-            # We can be filtering by more than one epic so epic_id can consist
-            # of different ids separated by comma. In that situation we will use
-            # only the first
-            if epic_id is not None:
-                epic_id = epic_id.split(",")[0]
+        qs = qs.prefetch_related("assigned_users")
+        include_attachments = "include_attachments" in self.request.QUERY_PARAMS
+        include_tasks = "include_tasks" in self.request.QUERY_PARAMS
 
-            qs = attach_extra_info(qs, user=self.request.user,
-                                   include_attachments=include_attachments,
-                                   include_tasks=include_tasks,
-                                   epic_id=epic_id)
+        epic_id = self.request.QUERY_PARAMS.get("epic", None)
+        # We can be filtering by more than one epic so epic_id can consist
+        # of different ids separated by comma. In that situation we will use
+        # only the first
+        if epic_id is not None:
+            epic_id = epic_id.split(",")[0]
+
+        qs = attach_extra_info(qs, user=self.request.user,
+                               include_attachments=include_attachments,
+                               include_tasks=include_tasks,
+                               epic_id=epic_id)
         return qs
 
     # Updating some attributes of the userstory can affect the ordering in the backlog, kanban or taskboard

--- a/taiga/projects/userstories/serializers.py
+++ b/taiga/projects/userstories/serializers.py
@@ -184,6 +184,11 @@ class UserStoryLightSerializer(ProjectExtraInfoSerializerMixin,
     blocked_note = Field()
 
 
+class UserStoryOnlyRefSerializer(serializers.LightSerializer):
+    id = Field()
+    ref = Field()
+
+
 class UserStoryNestedSerializer(ProjectExtraInfoSerializerMixin,
                                 StatusExtraInfoSerializerMixin,
                                 AssignedToExtraInfoSerializerMixin,

--- a/tests/integration/test_userstories.py
+++ b/tests/integration/test_userstories.py
@@ -1654,3 +1654,18 @@ def test_api_headers_userstories_without_swimlane_not_send(client):
     assert response.status_code == 200, response.data
     assert "taiga-info-userstories-without-swimlane" in response["access-control-expose-headers"]
     assert response.has_header("Taiga-Info-Userstories-Without-Swimlane") == False
+
+
+def test_api_list_userstory_using_onlyref_serializer(client):
+    project = f.create_project(owner=f.UserFactory.create() )
+    f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
+    us1 = f.create_userstory(project=project)
+    us2 = f.create_userstory(project=project)
+    us3 = f.create_userstory(project=project)
+
+    url = f"{reverse('userstories-list')}?only_ref=true"
+
+    client.login(project.owner)
+    response = client.json.get(url)
+    assert response.status_code == 200, response.data
+    assert set(response.data[0].keys()) == set(["id", "ref"])


### PR DESCRIPTION
Related to https://github.com/kaleidos-ventures/taiga-front/pull/92/

With this PR you can use a new serializaer with the endpoint`/api/v1/userstories` using the param `only_ref=true`