### PR TITLE
fix(trello_importer): tg-4782 Trello importer generate empty attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.5.0 (unreleased)
 
 - Now member limits by projects are counted by owner and not by project.
+- Fix Trello importer, now it does not generate empty attachments (issue #tg-4782)
 
 ## 6.4.3 (2021-10-27)
 


### PR DESCRIPTION
![](https://media.giphy.com/media/26hkhPJ5hmdD87HYA/giphy.gif)

Related to https://tree.taiga.io/project/taiga/issue/4782

## How to validate:
- [x] Review the code
- [x] Test: 
  - Create a project in trello with cards that contains attachments.
  - Import the project in Taiga
  - Check the content of the imported attachments. For example, you should see the images in the kanban (with max zoom level)