### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -336,7 +336,7 @@ def test_get_auth_token_error_inactive_user(client, settings):
     assert response.status_code == 401, response.data
 
 
-def test_get_auth_token_error_inactive_user(client, settings):
+def test_get_auth_token_error_inactive_user_two(client, settings):
     settings.PUBLIC_REGISTER_ENABLED = False
     user = factories.UserFactory(is_active=False)
 

--- a/tests/integration/test_hooks_bitbucket.py
+++ b/tests/integration/test_hooks_bitbucket.py
@@ -556,7 +556,7 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
     assert len(mail.outbox) == 0
 
 
-def test_push_event_task_bad_processing_non_existing_ref(client):
+def test_push_event_task_bad_processing_non_existing_ref_two(client):
     issue_status = f.IssueStatusFactory()
     payload = {
         "actor": {

--- a/tests/integration/test_hooks_gitlab.py
+++ b/tests/integration/test_hooks_gitlab.py
@@ -1095,7 +1095,7 @@ def test_issues_event_opened_issue_connected_with_external_one(client):
     assert issue.status == issue.project.default_issue_status
 
 
-def test_issues_event_updated_issue_without_connection(client):
+def test_issues_event_updated_issue_without_connection_two(client):
     issue = f.IssueFactory.create(external_reference=[])
     issue.project.default_issue_status = issue.status
     issue.project.default_issue_type = issue.type

--- a/tests/integration/test_memberships.py
+++ b/tests/integration/test_memberships.py
@@ -731,7 +731,7 @@ def test_api_edit_membership(client):
     assert response.status_code == 200
 
 
-def test_api_edit_membership(client):
+def test_api_edit_membership_two(client):
     membership = f.MembershipFactory(is_admin=True)
     client.login(membership.user)
     url = reverse("memberships-detail", args=[membership.id])

--- a/tests/integration/test_userstories_update_backlog_order.py
+++ b/tests/integration/test_userstories_update_backlog_order.py
@@ -609,7 +609,7 @@ def test_api_update_orders_in_bulk_invalid_after_us_because_no_milestone(client)
     assert "after_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_after_us_because_project(client):
+def test_api_update_orders_in_bulk_invalid_after_us_because_project_two(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     us1 = f.create_userstory(project=project)
@@ -635,7 +635,7 @@ def test_api_update_orders_in_bulk_invalid_after_us_because_project(client):
     assert "before_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_after_us_because_milestone(client):
+def test_api_update_orders_in_bulk_invalid_after_us_because_milestone_two(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     milestone = f.MilestoneFactory.create(project=project)
@@ -664,7 +664,7 @@ def test_api_update_orders_in_bulk_invalid_after_us_because_milestone(client):
     assert "before_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_after_us_because_no_milestone(client):
+def test_api_update_orders_in_bulk_invalid_after_us_because_no_milestone_two(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     milestone = f.MilestoneFactory.create(project=project)

--- a/tests/integration/test_userstories_update_backlog_order.py
+++ b/tests/integration/test_userstories_update_backlog_order.py
@@ -635,7 +635,7 @@ def test_api_update_orders_in_bulk_invalid_after_us_because_project_two(client):
     assert "before_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_after_us_because_milestone_two(client):
+def test_api_update_orders_in_bulk_invalid_after_us_because_milestone_three(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     milestone = f.MilestoneFactory.create(project=project)
@@ -664,7 +664,7 @@ def test_api_update_orders_in_bulk_invalid_after_us_because_milestone_two(client
     assert "before_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_after_us_because_no_milestone_two(client):
+def test_api_update_orders_in_bulk_invalid_after_us_because_no_milestone_four(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     milestone = f.MilestoneFactory.create(project=project)


### PR DESCRIPTION
Fixes #81.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

