### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/tests/integration/test_hooks_bitbucket.py
+++ b/tests/integration/test_hooks_bitbucket.py
@@ -565,7 +565,7 @@ def test_push_event_task_bad_processing_non_existing_ref(client):
     assert len(mail.outbox) == 0
 
 
-def test_push_event_task_bad_processing_non_existing_ref(client):
+def test_push_event_task_bad_processing_non_existing_ref_two(client):
     issue_status = f.IssueStatusFactory()
     payload = {
         "actor": {

--- a/tests/integration/test_hooks_gitlab.py
+++ b/tests/integration/test_hooks_gitlab.py
@@ -1104,7 +1104,7 @@ def test_issues_event_opened_issue_connected_with_external_one(client):
     assert issue.status == issue.project.default_issue_status
 
 
-def test_issues_event_updated_issue_without_connection(client):
+def test_issues_event_updated_issue_without_connection_two(client):
     issue = f.IssueFactory.create(external_reference=[])
     issue.project.default_issue_status = issue.status
     issue.project.default_issue_type = issue.type

--- a/tests/integration/test_memberships.py
+++ b/tests/integration/test_memberships.py
@@ -637,7 +637,7 @@ def test_api_edit_membership(client):
     assert response.status_code == 200
 
 
-def test_api_edit_membership(client):
+def test_api_edit_membership_two(client):
     membership = f.MembershipFactory(is_admin=True)
     client.login(membership.user)
     url = reverse("memberships-detail", args=[membership.id])

--- a/tests/integration/test_userstories_update_kanban_order.py
+++ b/tests/integration/test_userstories_update_kanban_order.py
@@ -737,7 +737,7 @@ def test_api_update_orders_in_bulk_invalid_affter_us_because_no_swimlane(client)
     assert "after_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_affter_us_because_project(client):
+def test_api_update_orders_in_bulk_invalid_affter_us_because_project_two(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     status = f.UserStoryStatusFactory.create(project=project)
@@ -767,7 +767,7 @@ def test_api_update_orders_in_bulk_invalid_affter_us_because_project(client):
     assert "before_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_affter_us_because_status(client):
+def test_api_update_orders_in_bulk_invalid_affter_us_because_status_two(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     status = f.UserStoryStatusFactory.create(project=project)
@@ -798,7 +798,7 @@ def test_api_update_orders_in_bulk_invalid_affter_us_because_status(client):
     assert "before_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_affter_us_because_swimlane(client):
+def test_api_update_orders_in_bulk_invalid_affter_us_because_swimlane_two(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     status = f.UserStoryStatusFactory.create(project=project)
@@ -829,7 +829,7 @@ def test_api_update_orders_in_bulk_invalid_affter_us_because_swimlane(client):
     assert "before_userstory_id" in response.data
 
 
-def test_api_update_orders_in_bulk_invalid_affter_us_because_no_swimlane(client):
+def test_api_update_orders_in_bulk_invalid_affter_us_because_no_swimlane_two(client):
     project = f.create_project()
     f.MembershipFactory.create(project=project, user=project.owner, is_admin=True)
     status = f.UserStoryStatusFactory.create(project=project)


### PR DESCRIPTION
Fixes #1618.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

