### PR TITLE
feat: improve webhooks security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.6.3 (unreleased)
 
-- ...
+- Security improvements to webhooks functionality.
 
 ## 6.6.2 (2023-03-24)
 

--- a/requirements.in
+++ b/requirements.in
@@ -20,14 +20,14 @@ python-dateutil==2.7.5
 python-magic==0.4.15
 pytz
 raven
-redis==4.5.1
+redis==4.5.3
 requests==2.27.1
 requests_oauthlib
 rudder-sdk-python==1.0.0b1
 serpy==0.1.1
 webcolors==1.9.1
 CairoSVG>=2.5.1
-Django>=3,<4
+Django>=3.2.19,<4
 Markdown==3.4.1
 pymdown-extensions==9.9.2
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ defusedxml==0.7.1
     # via cairosvg
 diff-match-patch==20121119
     # via -r requirements.in
-django==3.2.18
+django==3.2.19
     # via
     #   -r requirements.in
     #   django-jinja
@@ -173,7 +173,7 @@ pywavelets==1.4.1
     # via scikit-image
 raven==6.10.0
     # via -r requirements.in
-redis==4.5.1
+redis==4.5.3
     # via -r requirements.in
 requests==2.27.1
     # via

--- a/settings/common.py
+++ b/settings/common.py
@@ -598,8 +598,8 @@ GITLAB_VALID_ORIGIN_IPS = []
 EXPORTS_TTL = 60 * 60 * 24  # 24 hours
 
 WEBHOOKS_ENABLED = False
-WEBHOOKS_BLOCK_PRIVATE_ADDRESS = False
-
+WEBHOOKS_ALLOW_PRIVATE_ADDRESS = False
+WEBHOOKS_ALLOW_REDIRECTS = False
 
 # If is True /front/sitemap.xml show a valid sitemap of taiga-front client
 FRONT_SITEMAP_ENABLED = False

--- a/taiga/webhooks/validators.py
+++ b/taiga/webhooks/validators.py
@@ -22,7 +22,7 @@ class WebhookValidator(validators.ModelValidator):
         model = Webhook
 
     def validate_url(self, attrs, source):
-        if settings.WEBHOOKS_BLOCK_PRIVATE_ADDRESS:
+        if not settings.WEBHOOKS_ALLOW_PRIVATE_ADDRESS:
             host = urlparse(attrs[source]).hostname
             try:
                 ipa = ipaddress.ip_address(host)


### PR DESCRIPTION
![](https://media.giphy.com/media/IwTWTsUzmIicM/giphy.gif)

You can control the webhook's behavior with three settings

- `WEBHOOKS_ENABLED = False`: enable send webhooks (disable by default).
- `WEBHOOKS_ALLOW_PRIVATE_ADDRESS = False`: allow to send request to a private IP (deny by default).
-  `WEBHOOKS_ALLOW_REDIRECTS = False` allow to send request to urls who makes a (temporarily or permanently) redirect (deny by default).

# How to test:

- [x] Test the behavior of webhooks with `WEBHOOKS_ENABLED = False`
- [x] Test the behavior of webhooks playing with `WEBHOOKS_ALLOW_PRIVATE_ADDRESS`. You can use "/etc/hosts" to link hosts to private IPs
- [x] Test the behavior of webhooks playing with `WEBHOOKS_ALLOW_REDIRECTS`. You can use a nginx docker image to create redirections.