### PR TITLE
feat: make migrations compatible with Postgres 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.6.3 (unreleased)
 
 - Security improvements to webhooks functionality.
+- Make migrations compatible with Postgresql-14
 
 ## 6.6.2 (2023-03-24)
 


### PR DESCRIPTION
![](https://media.giphy.com/media/MdAGwO4XLfSarqMsSV/giphy-downsized.gif)

This PR adds compatibility with Postgres14, for new instances, as it changes a migration. Currently active instances should use the migration tutorial.

How to review:
- [x] check the code
- [x] build a new docker image for taiga-back
- [x] delete data volume for taiga-docker
- [x] change docker-compose.yml to use postgrse14
- [x] docker-compose up -d --> check everything is ok
- [x] ./taiga-manage.sh createsuperuser --> log in http://localhost:9000 and check everything is ok
- [x] ./taiga-manage.sh sample_data --> log again, lots of sample data and check everything is ok