### PR TITLE
- Improved RabbitMQ host configuration for Taiga events and asynchrous tasks.

### DIFF
--- a/docker/config.py
+++ b/docker/config.py
@@ -85,7 +85,7 @@ EVENTS_PUSH_BACKEND = "taiga.events.backends.rabbitmq.EventsPushBackend"
 
 EVENTS_PUSH_BACKEND_URL = os.getenv('EVENTS_PUSH_BACKEND_URL')
 if not EVENTS_PUSH_BACKEND_URL:
-    EVENTS_PUSH_BACKEND_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@taiga-events-rabbitmq:5672/taiga"
+    EVENTS_PUSH_BACKEND_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@{ os.getenv('TAIGA_EVENTS_RABBITMQ_HOST', 'taiga-events-rabbitmq') }:5672/taiga"
 
 EVENTS_PUSH_BACKEND_OPTIONS = {
     "url": EVENTS_PUSH_BACKEND_URL
@@ -100,7 +100,7 @@ from kombu import Queue  # noqa
 
 CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL')
 if not CELERY_BROKER_URL:
-    CELERY_BROKER_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@taiga-async-rabbitmq:5672/taiga"
+    CELERY_BROKER_URL = f"amqp://{ os.getenv('RABBITMQ_USER') }:{ os.getenv('RABBITMQ_PASS') }@{ os.getenv('TAIGA_ASYNC_RABBITMQ_HOST', 'taiga-async-rabbitmq') }:5672/taiga"
 
 CELERY_RESULT_BACKEND = None # for a general installation, we don't need to store the results
 CELERY_ACCEPT_CONTENT = ['pickle', ]  # Values are 'pickle', 'json', 'msgpack' and 'yaml'


### PR DESCRIPTION
- Utilized environment variables with default values for RabbitMQ hosts.

- Updated Taiga events RabbitMQ host configuration to use the environment variable `TAIGA_EVENTS_RABBITMQ_HOST`, with a default value of 'taiga-events-rabbitmq'.
- Revised asynchronous tasks RabbitMQ host configuration to use the environment variable `TAIGA_ASYNC_RABBITMQ_HOST`, with a default value of 'taiga-async-rabbitmq'.

This enhancement provides more flexibility in configuring RabbitMQ hosts for Taiga events and asynchronous tasks. Utilizing environment variables allows for easy customization, and default values ensure seamless deployment with minimal configuration.

LINKED TO = https://github.com/kaleidos-ventures/taiga-events/pull/8