### PR TITLE
Add pgbouncer support to the docker container

### DIFF
--- a/docker/config.py
+++ b/docker/config.py
@@ -23,6 +23,7 @@ DATABASES = {
         'HOST': os.getenv('POSTGRES_HOST'),
         'PORT': os.getenv('POSTGRES_PORT','5432'),
         'OPTIONS': {'sslmode': os.getenv('POSTGRES_SSLMODE','disable')},
+        'DISABLE_SERVER_SIDE_CURSORS': os.getenv('POSTGRES_DISABLE_SERVER_SIDE_CURSORS', 'False') == 'True',
     }
 }
 SECRET_KEY = os.getenv('TAIGA_SECRET_KEY')


### PR DESCRIPTION
Add the ability to configure the DISABLE_SERVER_SIDE_CURSORS parameter via environment variables.

Our company uses pgbouncer in front of the database. To work properly with pgbouncer we need to disable server-side cursors. I changed the settings file during installation, but I would like a simpler option.

More info: https://docs.djangoproject.com/en/4.2/ref/settings/#disable-server-side-cursors