### PR TITLE
Fixes authentication on get_object_or_error

### DIFF
--- a/taiga/base/api/utils/__init__.py
+++ b/taiga/base/api/utils/__init__.py
@@ -55,9 +55,9 @@ def get_object_or_error(queryset, user, *filter_args, **filter_kwargs):
     (if the user is not logged in).
 
     """
+    if not user.is_authenticated:
+        raise NotAuthenticated
     try:
         return _get_object_or_404(queryset, *filter_args, **filter_kwargs)
     except (Http404, TypeError, ValueError):
-        if not user.is_authenticated:
-            raise NotAuthenticated
         raise Http404


### PR DESCRIPTION
This commit introduces a change on authentication verification when calling `get_object_or_error`.

Previously, authentication was checked only... if object was not found.

A typical example that has highlighted this problem:  before this commit if a user has generated a report URL, then this URL was available to anyone (even anonymous users) for private projects.

I think this can be considered as a breaking change (because authentication is now required for affected endpoints)