### PR TITLE
fix: handle missing object in CustomAttributesValuesWebhookSerializer

### DIFF
--- a/taiga/webhooks/serializers.py
+++ b/taiga/webhooks/serializers.py
@@ -141,6 +141,9 @@ class CustomAttributesValuesWebhookSerializerMixin(serializers.LightSerializer):
         raise NotImplementedError()
 
     def get_custom_attributes_values(self, obj):
+        if not obj:
+            return None
+
         def _use_name_instead_id_as_key_in_custom_attributes_values(custom_attributes, values):
             ret = {}
             for attr in custom_attributes:

--- a/tests/integration/test_webhook_serializers.py
+++ b/tests/integration/test_webhook_serializers.py
@@ -1,0 +1,12 @@
+import taiga.webhooks.serializers
+
+
+class TestCustomAttributesValuesWebhookSerializerMixin:
+    webhook_serializer_mixin = (
+        taiga.webhooks.serializers.CustomAttributesValuesWebhookSerializerMixin
+    )
+
+    def test_get_custom_attributes_values(self):
+        assert (
+            self.webhook_serializer_mixin().get_custom_attributes_values(None) is None
+        )


### PR DESCRIPTION
Adds a check to ensure that the object exists before attempting to call get_custom_attributes_values.