### PR TITLE
fix: MultipleObjectsReturned error in get neighbors

### DIFF
--- a/taiga/base/neighbors.py
+++ b/taiga/base/neighbors.py
@@ -69,7 +69,7 @@ def get_neighbors(obj, results_set=None):
         left = None
 
     try:
-        right = results_set.get(id=right_object_id)
+        right = results_set.filter(id=right_object_id).first()
     except ObjectDoesNotExist:
         right = None
 

--- a/tests/integration/test_neighbors.py
+++ b/tests/integration/test_neighbors.py
@@ -37,6 +37,17 @@ class TestUserStories:
         assert neighbors.left == us1
         assert neighbors.right == us3
 
+    def test_results_set_repeat_id(self):
+        project = f.ProjectFactory.create()
+
+        us1 = f.UserStoryFactory.create(project=project)
+        f.RolePointsFactory.create(user_story=us1)
+        f.RolePointsFactory.create(user_story=us1)
+
+        neighbors = n.get_neighbors(us1, results_set=UserStory.objects.get_queryset().filter(role_points__isnull=False))
+
+        assert neighbors.right == us1
+
     def test_filtered_by_tags(self):
         tag_names = ["test"]
         project = f.ProjectFactory.create()


### PR DESCRIPTION
While obtaining the neighbor to the right of obj, only one element was expected. In some rare cases, it was returning more than one element. I have added a filter to ensure that in these cases, only the first element is returned to avoid the error.