### PR TITLE
fix error on load_dump when json is a list

### DIFF
--- a/taiga/export_import/api.py
+++ b/taiga/export_import/api.py
@@ -8,6 +8,8 @@
 import codecs
 import uuid
 import gzip
+import logging
+
 
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
@@ -41,6 +43,7 @@ from . import throttling
 
 from taiga.base.api.utils import get_object_or_error
 
+logger = logging.getLogger(__name__)
 
 class ProjectExporterViewSet(mixins.ImportThrottlingPolicyMixin, GenericViewSet):
     model = Project
@@ -333,7 +336,12 @@ class ProjectImporterViewSet(mixins.ImportThrottlingPolicyMixin, CreateModelMixi
 
         try:
             dump = json.load(reader(dump))
+            
         except Exception:
+            raise exc.WrongArguments(_("Invalid dump format"))
+
+        if not isinstance(dump, dict):
+            logger.error("trying a load_dump with a different format than dict: {0}, from user {1}".format(dump, request.user))
             raise exc.WrongArguments(_("Invalid dump format"))
 
         slug = dump.get('slug', None)

--- a/tests/integration/test_importer_api.py
+++ b/tests/integration/test_importer_api.py
@@ -1222,6 +1222,26 @@ def test_valid_dump_import_error_without_enough_public_projects_slots(client, se
     assert Project.objects.filter(slug="public-project-without-slots").count() == 0
 
 
+def test_invalid_dump_json_list(client, settings):
+    user = f.UserFactory.create(max_public_projects=0)
+    client.login(user)
+
+    url = reverse("importer-load-dump")
+
+    data = ContentFile(bytes(json.dumps([{
+        "slug": "public-project-without-slots",
+        "name": "Valid project",
+        "description": "Valid project desc",
+        "is_private": False
+    }]), "utf-8"))
+    data.name = "test"
+
+    response = client.post(url, {'dump': data})
+    assert response.status_code == 400
+
+
+
+
 def test_valid_dump_import_error_without_enough_private_projects_slots(client, settings):
     user = f.UserFactory.create(max_private_projects=0)
     client.login(user)


### PR DESCRIPTION
Fixed an error in the load_dump function that caused it to crash when receiving data different from a dictionary.