### PR TITLE
Pivotal importer fixes

### DIFF
--- a/taiga/importers/management/commands/import_from_jira.py
+++ b/taiga/importers/management/commands/import_from_jira.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         parser.add_argument('--project-type', dest="project_type", type=str,
                             help='Project type in jira: project or board')
         parser.add_argument('--template', dest='template', default="scrum",
-                            help='template to use: scrum or scrum (default scrum)')
+                            help='template to use: scrum or kanban (default scrum)')
         parser.add_argument('--ask-for-users', dest='ask_for_users', const=True,
                             action="store_const", default=False,
                             help='Import closed data')

--- a/taiga/importers/management/commands/import_from_pivotal.py
+++ b/taiga/importers/management/commands/import_from_pivotal.py
@@ -20,9 +20,9 @@ class Command(BaseCommand):
                             help='Project ID or full name (ex: taigaio/taiga-back)')
         parser.add_argument('--template', dest='template', default="scrum",
                             help='template to use: scrum or kanban (default scrum)')
-        parser.add_argument('--ask-for-users', dest='ask_for_users', const=True,
+        parser.add_argument('--map-users', dest='map_users', const=True,
                             action="store_const", default=False,
-                            help='Import closed data')
+                            help='Map usernames from Pivotal to Taiga. You can create users in Taiga in advance via /admin/users/user')
         parser.add_argument('--closed-data', dest='closed_data', const=True,
                             action="store_const", default=False,
                             help='Import closed data')
@@ -50,24 +50,12 @@ class Command(BaseCommand):
             project_id = input("Project id: ")
 
         users_bindings = {}
-        if options.get('ask_for_users', None):
-            print("Add the username or email for next pivotal users:")
+        if options.get('map_users', None):
             for user in importer.list_users(project_id):
                 try:
-                    users_bindings[user['id']] = User.objects.get(Q(email=user['person'].get('email', "not-valid")))
-                    break
+                    users_bindings[user['person']['id']] = User.objects.get(Q(email=user['person'].get('email', "not-valid")))
                 except User.DoesNotExist:
                     pass
-
-                while True:
-                    username_or_email = input("{}: ".format(user['person']['name']))
-                    if username_or_email == "":
-                        break
-                    try:
-                        users_bindings[user['id']] = User.objects.get(Q(username=username_or_email) | Q(email=username_or_email))
-                        break
-                    except User.DoesNotExist:
-                        print("ERROR: Invalid username or email")
 
         options = {
             "template": options.get('template'),

--- a/taiga/importers/management/commands/import_from_pivotal.py
+++ b/taiga/importers/management/commands/import_from_pivotal.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         parser.add_argument('--project-id', dest="project_id", type=str,
                             help='Project ID or full name (ex: taigaio/taiga-back)')
         parser.add_argument('--template', dest='template', default="scrum",
-                            help='template to use: scrum or scrum (default scrum)')
+                            help='template to use: scrum or kanban (default scrum)')
         parser.add_argument('--ask-for-users', dest='ask_for_users', const=True,
                             action="store_const", default=False,
                             help='Import closed data')

--- a/taiga/importers/pivotal/importer.py
+++ b/taiga/importers/pivotal/importer.py
@@ -358,8 +358,13 @@ class PivotalImporter:
                     tags.append(label['name'])
 
                 assigned_to = None
+                assigned_users = []
                 if len(story['owner_ids']) > 0:
                     assigned_to = users_bindings.get(story['owner_ids'][0], None)
+                    for assignee in story['owner_ids']:
+                        bound_user = users_bindings.get(assignee, None)
+                        if bound_user:
+                            assigned_users.append(bound_user.id)
 
                 owner = users_bindings.get(story['requested_by_id'], self._user)
 
@@ -381,6 +386,9 @@ class PivotalImporter:
                     external_reference=external_reference,
                     milestone=story_milestone_binding.get(story['id'], None)
                 )
+
+                if assigned_users:
+                    us.assigned_users.set(assigned_users)
 
                 points = Points.objects.get(project=project, value=story.get('estimate', None))
                 RolePoints.objects.filter(user_story=us, role__slug="main").update(points_id=points.id)

--- a/taiga/importers/pivotal/importer.py
+++ b/taiga/importers/pivotal/importer.py
@@ -477,6 +477,11 @@ class PivotalImporter:
         users_bindings = options.get('users_bindings', {})
 
         for comment in story['comments']:
+            if not comment.get('person', False):
+                print(f"Person element is missing in comment {comment['id']} of story {story['id']}, will treat as unknown")
+                comment['person'] = {}
+                comment['person']['id'] = '0'
+                comment['person']['name'] = 'unknown'
             if 'text' in comment:
                 snapshot = take_snapshot(
                     obj,


### PR DESCRIPTION
Fixes https://github.com/taigaio/taiga-back/issues/175

 * Set a dummy person in comment when it is undefined.
 * Fix 'scrum or scrum' helper info on jira and pivotal commands.
 * Adds ability to import the Pull Request attributes from Pivotal into Taiga as a Custom Field.
 * Adds ability to capture the 'blocked' story/epic IDs from Pivotal in the 'blocked_text' field in Taiga.