### PR TITLE
fix: Updated 'tox' python configuration to compatible version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py310
 skipsdist = True
 
 [testenv]
@@ -11,7 +11,7 @@ commands =
 
 [testenv:flake8]
 deps = flake8
-basepython = python3.6
+basepython = python3.10
 commands = flake8 .
 
 [coverage:run]


### PR DESCRIPTION
- Updated tox to Python version 3.10 due the following packages: 
   - aggdraw, requires Python >= 3.7 
   - networkx, requires Python >= 3.8 
   - Many conflicts in Python 3.9