### PR TITLE
Use product_name from settings resolver in place of hardcoded 'Taiga'  in various Jinja templates

### DIFF
--- a/taiga/base/templates/emails/base-body-html.jinja
+++ b/taiga/base/templates/emails/base-body-html.jinja
@@ -11,7 +11,9 @@ Copyright (c) 2021-present Kaleidos INC
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>{{ _("Taiga") }}</title>
+        {% trans product_name=sr("product_name") %}
+        <title>{{ product_name }}</title>
+        {% endtrans %}
         <style type="text/css">
             /* /\/\/\/\/\/\/\/\/ CLIENT-SPECIFIC STYLES /\/\/\/\/\/\/\/\/ */
             #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" message */
@@ -347,7 +349,9 @@ Copyright (c) 2021-present Kaleidos INC
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateHeader"  style="background-color: #008AA8">
                                         <tr>
                                             <td valign="top" class="headerContent">
-                                                <a href="{{ resolve_front_url("home") }}" class="brand" title="Taiga">
+                                                {% trans product_name=sr("product_name") %}
+                                                <a href="{{ resolve_front_url("home") }}" class="brand" title="{{ product_name }}">
+                                                {% endtrans %}
                                                     <img src="{{ static("emails/logo-web.png") }}" />
                                                 </a>
                                             </td>

--- a/taiga/base/templates/emails/hero-body-html.jinja
+++ b/taiga/base/templates/emails/hero-body-html.jinja
@@ -300,10 +300,10 @@ Copyright (c) 2021-present Kaleidos INC
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateHeader">
                                         <tr>
                                             <td valign="top" class="headerContent" style="background-color: #008AA8;">
-                                                <a href="{{ resolve_front_url("home") }}" title="Taiga">
-                                                    <img src="{{ static("emails/logo.png") }}" id="headerImage" alt="Taiga" />
-                                                </a>
                                                 {% trans product_name=sr("product_name") %}
+                                                <a href="{{ resolve_front_url("home") }}" title="{{ product_name}}">
+                                                    <img src="{{ static("emails/logo.png") }}" id="headerImage" alt="{{ product_name }}" />
+                                                </a>
                                                 <p>Welcome to {{ product_name }}, an Open Source, Agile Project Management Tool</p>
                                                 {% endtrans %}
                                             </td>

--- a/taiga/base/templates/emails/includes/footer.jinja
+++ b/taiga/base/templates/emails/includes/footer.jinja
@@ -12,10 +12,10 @@ width="100%" id="templateFooter">
     <tr>
         <td valign="top">
             {% block footer %}
-                {% trans unsubscribe_url=resolve_front_url("settings-mail-notifications"), support_url=sr("support.url"), support_email=sr("support.email") %}
+                {% trans unsubscribe_url=resolve_front_url("settings-mail-notifications"), support_url=sr("support.url"), support_email=sr("support.email"), product_name=sr("product_name") %}
                 <a href="{{ unsubscribe_url }}">Configure email notifications or unsubscribe</a>
                 &nbsp;&bull;&nbsp;
-                <a href="{{ support_url }}">Taiga Support</a>
+                <a href="{{ support_url }}">{{ product_name }} Support</a>
                 &nbsp;&bull;&nbsp;
                 <a href="mailto:{{ support_email }}" >Contact us</a>
                 {% endtrans %}

--- a/taiga/base/templates/emails/updates-body-html.jinja
+++ b/taiga/base/templates/emails/updates-body-html.jinja
@@ -342,7 +342,9 @@ Copyright (c) 2021-present Kaleidos INC
                                             <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateHeader"  style="background-color: #008AA8">
                                                 <tr>
                                                     <td valign="top" class="headerContent">
-                                                        <a href="{{ resolve_front_url("home") }}" class="brand" title="Taiga">
+                                                        {% trans product_name=sr("product_name") %}
+                                                        <a href="{{ resolve_front_url("home") }}" class="brand" title="{{ product_name }}">
+                                                        {% endtrans %}
                                                             <img src="{{ static("emails/logo-web.png") }}" />
                                                         </a>
                                                     </td>

--- a/taiga/export_import/templates/emails/export_error-body-html.jinja
+++ b/taiga/export_import/templates/emails/export_error-body-html.jinja
@@ -9,11 +9,11 @@ Copyright (c) 2021-present Kaleidos INC
 {% extends "emails/base-body-html.jinja" %}
 
 {% block body %}
-    {% trans signature=sr("signature"), user=user.get_full_name(), error_message=error_message, support_email=sr("support.email"), project=project.name %}
+    {% trans signature=sr("signature"), user=user.get_full_name(), error_message=error_message, support_email=sr("support.email"), project=project.name, product_name=sr("product_name") %}
     <h1>{{ error_message }}</h1>
     <p>Hello {{ user }},</p>
     <p>Your project {{ project }} has not been exported correctly.</p>
-    <p>The Taiga system administrators have been informed.<br/> Please, try it again or contact with the support team at
+    <p>The {{ product_name }} system administrators have been informed.<br/> Please, try it again or contact with the support team at
        <a href="mailto:{{ support_email }}" title="Support email" style="color: #83EEDE">{{ support_email }}</a></p>
     <p><small>{{ signature }}</small></p>
     {% endtrans %}

--- a/taiga/export_import/templates/emails/export_error-body-text.jinja
+++ b/taiga/export_import/templates/emails/export_error-body-text.jinja
@@ -6,13 +6,13 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2021-present Kaleidos INC
 #}
 
-{% trans signature=sr("signature"), user=user.get_full_name(), error_message=error_message, support_email=sr("support.email"), project=project.name %}
+{% trans signature=sr("signature"), user=user.get_full_name(), error_message=error_message, support_email=sr("support.email"), project=project.name, product_name=sr("product_name") %}
 Hello {{ user }},
 
 {{ error_message }}
 Your project {{ project }} has not been exported correctly.
 
-The Taiga system administrators have been informed.
+The {{ product_name}} system administrators have been informed.
 
 Please, try it again or contact with the support team at {{ support_email }}
 

--- a/taiga/feedback/templates/emails/feedback_notification-body-html.jinja
+++ b/taiga/feedback/templates/emails/feedback_notification-body-html.jinja
@@ -9,9 +9,10 @@ Copyright (c) 2021-present Kaleidos INC
 {% extends "emails/base-body-html.jinja" %}
 
 {% block body %}
-    {% trans full_name=feedback_entry.full_name, email=feedback_entry.email %}
+    {% trans full_name=feedback_entry.full_name, email=feedback_entry.email, product_name=sr("product_name") %}
+
     <h1>Feedback</h1>
-    <p>Taiga has received feedback from {{ full_name }} <{{ email }}></p>
+    <p>{{ product_name }} has received feedback from {{ full_name }} <{{ email }}></p>
     {% endtrans %}
 
     {% trans comment=feedback_entry.comment|linebreaksbr %}

--- a/taiga/feedback/templates/emails/feedback_notification-subject.jinja
+++ b/taiga/feedback/templates/emails/feedback_notification-subject.jinja
@@ -6,6 +6,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2021-present Kaleidos INC
 #}
 
-{% trans full_name=feedback_entry.full_name|safe, email=feedback_entry.email|safe %}
-[Taiga] Feedback from {{ full_name }} <{{ email }}>
+{% trans full_name=feedback_entry.full_name|safe, email=feedback_entry.email|safe, product_name=sr("product_name") %}
+[{{ product_name }}] Feedback from {{ full_name }} <{{ email }}>
 {% endtrans %}

--- a/taiga/projects/contact/templates/emails/contact_notification-body-html.jinja
+++ b/taiga/projects/contact/templates/emails/contact_notification-body-html.jinja
@@ -25,8 +25,8 @@ Copyright (c) 2021-present Kaleidos INC
     <hr>
 
     <p>
-    {% trans project_name=project_name, project_settings_url=project_settings_url %}
-        You are receiving this message because you are listed as administrator of the project titled {{ project_name }}. If you don't want members of the Taiga community contacting your project, please <a href="{{ project_settings_url }}">update your project settings</a> to prevent such contacts. Regular communications amongst members of the project will not be affected.
+    {% trans project_name=project_name, project_settings_url=project_settings_url, product_name=sr("product_name") %}
+        You are receiving this message because you are listed as administrator of the project titled {{ project_name }}. If you don't want members of the {{ product_name }} community contacting your project, please <a href="{{ project_settings_url }}">update your project settings</a> to prevent such contacts. Regular communications amongst members of the project will not be affected.
     {% endtrans %}
     </p>
 

--- a/taiga/projects/contact/templates/emails/contact_notification-body-text.jinja
+++ b/taiga/projects/contact/templates/emails/contact_notification-body-text.jinja
@@ -12,8 +12,8 @@ Copyright (c) 2021-present Kaleidos INC
 ---------
 {{ comment }}
 ---------
-{% trans project_name=project_name %}
-You are receiving this message because you are listed as administrator of the project titled {{ project_name }}. If you don't want members of the Taiga community contacting your project, please update your project settings in {{ project_settings_url }} to prevent such contacts. Regular communications amongst members of the project will not be affected.
+{% trans project_name=project_name, product_name=sr("product_name") %}
+You are receiving this message because you are listed as administrator of the project titled {{ project_name }}. If you don't want members of the {{ product_name}} community contacting your project, please update your project settings in {{ project_settings_url }} to prevent such contacts. Regular communications amongst members of the project will not be affected.
 {% endtrans %}
 
 {% trans signature=sr("signature") %}

--- a/taiga/projects/contact/templates/emails/contact_notification-subject.jinja
+++ b/taiga/projects/contact/templates/emails/contact_notification-subject.jinja
@@ -6,6 +6,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2021-present Kaleidos INC
 #}
 
-{% trans full_name=full_name|safe, project_name=project_name|safe %}
-[Taiga] {{ full_name }} has sent a message to the project {{ project_name }}
+{% trans full_name=full_name|safe, project_name=project_name|safe, product_name=sr("product_name") %}
+[{{ product_name }}] {{ full_name }} has sent a message to the project {{ project_name }}
 {% endtrans %}

--- a/taiga/projects/templates/emails/membership_invitation-body-html.jinja
+++ b/taiga/projects/templates/emails/membership_invitation-body-html.jinja
@@ -18,7 +18,7 @@ Copyright (c) 2021-present Kaleidos INC
 {% block body %}
     {% trans full_name=sender_full_name, project=membership.project, product_name=sr("product_name") %}
     <h2>You have been invited to {{ product_name }}!</h2>
-<p>Hi! {{ full_name }} has sent you an invitation to join project <em>{{ project }}</em> in {{ product_name }}.</br> Taiga is an Open Source Agile Project Management Tool. There is no cost for you to be a Taiga user.</p>
+<p>Hi! {{ full_name }} has sent you an invitation to join project <em>{{ project }}</em> in {{ product_name }}.</br> {{ product_name }} is an Open Source Agile Project Management Tool. There is no cost for you to be a {{ product_name }} user.</p>
     {% endtrans %}
 
     {% if membership.invitation_extra_text %}
@@ -29,7 +29,7 @@ Copyright (c) 2021-present Kaleidos INC
     {% endif %}
 
     <a class="button" href="{{ resolve_front_url("invitation", membership.token) }}"
-       title="{{ _("Accept your invitation to Taiga") }}">{{ _("Accept your invitation") }}</a>
+       title="{{ _("Accept your invitation") }}">{{ _("Accept your invitation") }}</a>
     {% trans signature=sr("signature") %}
     <p><small>{{ signature }}</small></p>
     {% endtrans %}

--- a/taiga/projects/templates/emails/membership_invitation-body-text.jinja
+++ b/taiga/projects/templates/emails/membership_invitation-body-text.jinja
@@ -15,7 +15,7 @@ Copyright (c) 2021-present Kaleidos INC
 You, or someone you know, has invited you to {{ product_name }}
 
 Hi! {{ full_name }} has sent you an invitation to join a project called {{ project }} in {{ product_name }}.
-Taiga is an Open Source Agile Project Management Tool. There is no cost for you to be a Taiga user.
+{{ product_name }} is an Open Source Agile Project Management Tool. There is no cost for you to be a {{ product_name }} user.
 
 {% endtrans %}
 {% if membership.invitation_extra_text %}
@@ -25,7 +25,7 @@ And now a few words from the jolly good fellow or sistren who thought so kindly 
 {{ extra }}
     {% endtrans %}
 {% endif %}
-{{ _("Accept your invitation to Taiga following this link:") }}
+{{ _("Accept your invitation by following this link:") }}
 {{ resolve_front_url("invitation", membership.token) }}
 
 {% trans signature=sr("signature") %}

--- a/taiga/projects/templates/emails/membership_invitation-subject.jinja
+++ b/taiga/projects/templates/emails/membership_invitation-subject.jinja
@@ -6,6 +6,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2021-present Kaleidos INC
 #}
 
-{% trans project=membership.project|safe %}
-[Taiga] Invitation to join to the project '{{ project }}'
+{% trans project=membership.project|safe, product_name=sr("product_name") %}
+[{{ product_name }}] Invitation to join to the project '{{ project }}'
 {% endtrans %}

--- a/taiga/projects/templates/emails/membership_notification-subject.jinja
+++ b/taiga/projects/templates/emails/membership_notification-subject.jinja
@@ -6,6 +6,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2021-present Kaleidos INC
 #}
 
-{% trans project=membership.project|safe %}
-[Taiga] Added to the project '{{ project }}'
+{% trans project=membership.project|safe, product_name=sr("product_name") %}
+[{{ product_name }}] Added to the project '{{ project }}'
 {% endtrans %}


### PR DESCRIPTION
There is inconsistent use of the `product_name` attribute of the settings resolver. In many places 'Taiga' is hardcoded. It would be great to be able to consistently replace 'Taiga' with a business-specific app name in the Jinja-generated content, in this way.