### PR TITLE
Fix swimlane deletion error: (bug # 197)

### DIFF
--- a/taiga/projects/services/bulk_update_order.py
+++ b/taiga/projects/services/bulk_update_order.py
@@ -291,8 +291,8 @@ def update_order_and_swimlane(swimlane_to_be_deleted, move_to_swimlane):
         execute_values(curs,
                        """
                        UPDATE userstories_userstory
-                       SET kanban_order = tmp.new_order,
-                           swimlane_id = tmp.sid
+                       SET kanban_order = tmp.new_order::BIGINT,
+                           swimlane_id = tmp.sid::INTEGER
                        FROM (VALUES %s) AS tmp (sid, ussid, new_order)
                        WHERE tmp.ussid = userstories_userstory.id""",
                        data)


### PR DESCRIPTION
Fixed bug #197: deleting an empty swimlane returned a 500 due to a PostgreSQL type mismatch in the bulk update during deletion (the temp VALUES table inferred tmp.sid as text while userstories_userstory.swimlane_id is integer). Changed SQL in taiga/projects/services/bulk_update_order.py (update_order_and_swimlane) to explicitly cast types: swimlane_id = tmp.sid::INTEGER and kanban_order = tmp.new_order::BIGINT. This removes reliance on type inference and resolves the crash.