### PR TITLE
Fix: prevent internal server error when deleting empty swimlane (#197)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ static
 .direnv
 settings/config.py
 celerybeat-schedule
+.vscode

--- a/taiga/projects/mixins/on_destroy.py
+++ b/taiga/projects/mixins/on_destroy.py
@@ -84,8 +84,9 @@ class MoveOnDestroySwimlaneMixin:
                 raise exc.BadRequest(_("Cannot set swimlane to None if there are available swimlanes"))
 
             # but if it was the last swimlane,
-            # it can be deleted and all uss have now swimlane=None
-            obj.user_stories.update(swimlane_id=None)
+            # allow deletion and unlink related user stories
+            if obj.user_stories:
+                obj.user_stories.update(swimlane_id=None)
         else:
             move_item = get_object_or_404(self.model, id=move_to)
 


### PR DESCRIPTION
Fix issue #197  -  deleting an empty swimlane caused an Internal Server Error.

Fix implemented:

- Added a simple check before updating related user stories to safely handle empty simlanes.
- This prevents `.update()` from being called when there are no linked user stories, avoiding the creas.
- Tested locally - deleting an empty swimlane now returns `204 No content `without errors