### PR TITLE
Add legacy-cgi for Python 3.13 compatibility (fixes #219)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -109,6 +109,8 @@ lazy-loader==0.4
     # via scikit-image
 lxml==6.0.2
     # via premailer
+legacy-cgi==2.6.4
+    # via -r requirements.in    
 markdown==3.10
     # via
     #   -r requirements.in


### PR DESCRIPTION
i think adding adding legacy-cgi==2.6.4 in requerements.txt will resolve this issue!
FIXES #219 