### PR TITLE
Apply FORCE_SCRIPT_NAME to API domain in SITES config

### DIFF
--- a/docker/config.py
+++ b/docker/config.py
@@ -35,8 +35,8 @@ FORCE_SCRIPT_NAME = os.getenv('TAIGA_SUBPATH', '')
 
 TAIGA_URL = f"{ TAIGA_SITES_SCHEME }://{ TAIGA_SITES_DOMAIN }{ FORCE_SCRIPT_NAME }"
 SITES = {
-        "api": { "name": "api", "scheme": TAIGA_SITES_SCHEME, "domain": TAIGA_SITES_DOMAIN },
-        "front": { "name": "front", "scheme": TAIGA_SITES_SCHEME, "domain": f"{ TAIGA_SITES_DOMAIN }{ FORCE_SCRIPT_NAME }" }
+    "api": { "name": "api", "scheme": TAIGA_SITES_SCHEME, "domain": f"{ TAIGA_SITES_DOMAIN }{ FORCE_SCRIPT_NAME }" },
+    "front": { "name": "front", "scheme": TAIGA_SITES_SCHEME, "domain": f"{ TAIGA_SITES_DOMAIN }{ FORCE_SCRIPT_NAME }" }
 }
 
 LANGUAGE_CODE = os.getenv("LANGUAGE_CODE", "en-us")


### PR DESCRIPTION
The TAIGA_SUBPATH environment variable was only being applied to the frontend domain but not the API domain, preventing proper deployment behind reverse proxies at non-root paths (e.g., /taiga).

This fix ensures both API and frontend use the same subpath configuration for consistent URL generation.

fix #217 