### PR TITLE
fix: replace 9 bare except clauses with except Exception

### DIFF
--- a/taiga/base/api/request.py
+++ b/taiga/base/api/request.py
@@ -391,7 +391,7 @@ class Request(object):
 
         try:
             parsed = parser.parse(stream, media_type, self.parser_context)
-        except:
+        except Exception:
             # If we get an exception during parsing, fill in empty data and
             # re-raise.  Ensures we don't simply repeat the error when
             # attempting to render the browsable renderer response, or when

--- a/taiga/base/api/utils/encoders.py
+++ b/taiga/base/api/utils/encoders.py
@@ -85,7 +85,7 @@ class JSONEncoder(json.JSONEncoder):
         elif hasattr(o, "__getitem__"):
             try:
                 return dict(o)
-            except:
+            except Exception:
                 pass
         elif hasattr(o, "__iter__"):
             return [i for i in o]

--- a/taiga/base/filters.py
+++ b/taiga/base/filters.py
@@ -143,7 +143,7 @@ class PermissionBasedFilterBackend(FilterBackend):
                 "project" in request.QUERY_PARAMS):
             try:
                 project_id = int(request.QUERY_PARAMS["project"])
-            except:
+            except Exception:
                 logger.error("Filtering project diferent value than an integer: {}".format(
                     request.QUERY_PARAMS["project"]
                 ))
@@ -268,7 +268,7 @@ class MembersFilterBackend(PermissionBasedFilterBackend):
         if "project" in request.QUERY_PARAMS:
             try:
                 project_id = int(request.QUERY_PARAMS["project"])
-            except:
+            except Exception:
                 logger.error("Filtering project diferent value than an integer: {}".format(
                     request.QUERY_PARAMS["project"]))
                 raise exc.BadRequest(_("'project' must be an integer value."))
@@ -388,7 +388,7 @@ class BaseRelatedFieldsFilter(FilterBackend):
         def _transform_value(value):
             try:
                 return int(value)
-            except:
+            except Exception:
                 if value in self._special_values_dict:
                     return self._special_values_dict[value]
             raise exc.BadRequest()

--- a/taiga/importers/github/importer.py
+++ b/taiga/importers/github/importer.py
@@ -540,7 +540,7 @@ class GithubImporter:
         else:
             try:
                 return dict(parse_qsl(result.content))[b'access_token'].decode('utf-8')
-            except:
+            except Exception:
                 raise InvalidAuthResult()
 
 

--- a/taiga/importers/trello/importer.py
+++ b/taiga/importers/trello/importer.py
@@ -132,7 +132,7 @@ class TrelloImporter:
                     avatar = 'https://www.gravatar.com/avatar/' + user['gravatarHash'] + '.jpg?s=50'
                 elif user['avatarHash'] is not None:
                     avatar = 'https://trello-members.s3.amazonaws.com/' +  user['id'] +  '/' + user['avatarHash'] + '/50.png'
-            except:
+            except Exception:
                 # NOTE: Sometimes this piece of code return this exception:
                 #
                 # File "/home/taiga/taiga-back/taiga/importers/trello/importer.py" in list_users

--- a/taiga/projects/filters.py
+++ b/taiga/projects/filters.py
@@ -48,7 +48,7 @@ class CanViewProjectObjFilterBackend(FilterBackend):
                 "project" in request.QUERY_PARAMS):
             try:
                 project_id = int(request.QUERY_PARAMS["project"])
-            except:
+            except Exception:
                 logger.error("Filtering project diferent value than an integer: {}".format(
                     request.QUERY_PARAMS["project"]
                 ))

--- a/taiga/projects/references/api.py
+++ b/taiga/projects/references/api.py
@@ -77,7 +77,7 @@ class ResolverViewSet(viewsets.ViewSet):
                     issue = project.issues.filter(ref=value).first()
                     if issue:
                         result["issue"] = issue.pk
-            except:
+            except Exception:
                 value = data["ref"]
 
                 if user_has_perm(request.user, "view_wiki_pages", project):


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches all exceptions including SystemExit, KeyboardInterrupt, and GeneratorExit, which is rarely intended.