### PR TITLE
Issue 253: Updated epic id setting in utils to allow for null epic when filtering

### DIFF
--- a/taiga/projects/userstories/utils.py
+++ b/taiga/projects/userstories/utils.py
@@ -136,8 +136,8 @@ def attach_epic_order(queryset, epic_id, as_field="epic_order"):
                FROM "epics_relateduserstory"
               WHERE "epics_relateduserstory"."user_story_id" = {tbl}.id and
                     "epics_relateduserstory"."epic_id" = {epic_id}"""
-
-    sql = sql.format(tbl=model._meta.db_table, epic_id=int(epic_id))
+    epicId = epic_id if epic_id is not None else 0
+    sql = sql.format(tbl=model._meta.db_table, epic_id=epicId)
     queryset = queryset.extra(select={as_field: sql})
     return queryset
 


### PR DESCRIPTION
When a user doesn't have any epics and they select the filter by epics in the backlog, then the epic ID for tasks will be null and this would throw an NPE.

This is a backlog with more than 4 tasks, all disappeared once this NPE hit, further the filter options disappear to so they cannot undo it; then it gets stuck like this:
<img width="1608" height="827" alt="Screenshot 2026-03-06 210038" src="https://github.com/user-attachments/assets/be1685b2-9718-4a2c-83a1-c1d8d336bc91" />

This is after the fix showing 1 task under a created epic being filtered out and the remaining displayed, also shows the filter bar options reappeared:
<img width="1511" height="619" alt="Screenshot 2026-03-06 212428" src="https://github.com/user-attachments/assets/375646d8-3804-4ac6-8ba7-64e72c9e100c" />
