### PR TITLE
Add embed user stories and tasks in project detail response ([FR] #115)

### DIFF
--- a/taiga/projects/api.py
+++ b/taiga/projects/api.py
@@ -129,6 +129,18 @@ class ProjectViewSet(LikedResourceMixin, HistoryResourceMixin,
         elif order_by_field_name == "total_activity_last_year":
             qs = qs.filter(totals_updated_datetime__gte=now - relativedelta(years=1))
 
+        include_params = [
+            p.strip()
+            for p in self.request.QUERY_PARAMS.get("include", "").split(",")
+            if p.strip()
+        ]
+        if "userstories" in include_params:
+            qs = project_utils.attach_userstories_to_project(qs)
+            qs = qs.extra(select={"include_userstories": "True"})
+        if "tasks" in include_params:
+            qs = project_utils.attach_tasks_to_project(qs)
+            qs = qs.extra(select={"include_tasks": "True"})
+
         return qs
 
     def retrieve(self, request, *args, **kwargs):

--- a/taiga/projects/serializers.py
+++ b/taiga/projects/serializers.py
@@ -441,6 +441,8 @@ class ProjectDetailSerializer(ProjectSerializer):
     issues_csv_uuid = Field()
     transfer_token = Field()
     milestones = MethodField()
+    userstories = MethodField()
+    tasks = MethodField()
 
     def get_milestones(self, obj):
         assert hasattr(obj, "milestones_attr"), "instance must have a milestones_attr attribute"
@@ -448,6 +450,22 @@ class ProjectDetailSerializer(ProjectSerializer):
             return []
 
         return obj.milestones_attr
+
+    def get_userstories(self, obj):
+        include_userstories = getattr(obj, "include_userstories", False)
+        if include_userstories:
+            assert hasattr(obj, "userstories_attr"), "instance must have a userstories_attr attribute"
+        if not include_userstories or obj.userstories_attr is None:
+            return []
+        return obj.userstories_attr
+
+    def get_tasks(self, obj):
+        include_tasks = getattr(obj, "include_tasks", False)
+        if include_tasks:
+            assert hasattr(obj, "tasks_attr"), "instance must have a tasks_attr attribute"
+        if not include_tasks or obj.tasks_attr is None:
+            return []
+        return obj.tasks_attr
 
     def to_value(self, instance):
         # Name attributes must be translated

--- a/taiga/projects/utils.py
+++ b/taiga/projects/utils.py
@@ -621,3 +621,78 @@ def attach_basic_info(queryset, user=None):
     queryset = attach_my_homepage(queryset, user)
 
     return queryset
+
+
+def attach_userstories_to_project(queryset, as_field="userstories_attr"):
+    """Attach a json user stories representation to each object of the queryset.
+
+    :param queryset: A Django projects queryset object.
+    :param as_field: Attach the user stories as an attribute with this name.
+
+    :return: Queryset object with the additional `as_field` field.
+    """
+    model = queryset.model
+    sql = """
+             SELECT json_agg(row_to_json(t))
+               FROM (
+                        SELECT userstories_userstory.id,
+                               userstories_userstory.ref,
+                               userstories_userstory.subject,
+                               userstories_userstory.status_id,
+                               userstories_userstory.is_closed,
+                               userstories_userstory.created_date,
+                               userstories_userstory.modified_date,
+                               userstories_userstory.finish_date,
+                               userstories_userstory.backlog_order,
+                               userstories_userstory.sprint_order,
+                               userstories_userstory.kanban_order,
+                               userstories_userstory.milestone_id,
+                               userstories_userstory.assigned_to_id,
+                               userstories_userstory.is_blocked
+                          FROM userstories_userstory
+                         WHERE userstories_userstory.project_id = {tbl}.id
+                      ORDER BY userstories_userstory.backlog_order,
+                               userstories_userstory.ref
+                    ) t
+          """
+
+    sql = sql.format(tbl=model._meta.db_table)
+    queryset = queryset.extra(select={as_field: sql})
+    return queryset
+
+
+def attach_tasks_to_project(queryset, as_field="tasks_attr"):
+    """Attach a json tasks representation to each object of the queryset.
+
+    :param queryset: A Django projects queryset object.
+    :param as_field: Attach the tasks as an attribute with this name.
+
+    :return: Queryset object with the additional `as_field` field.
+    """
+    model = queryset.model
+    sql = """
+             SELECT json_agg(row_to_json(t))
+               FROM (
+                        SELECT tasks_task.id,
+                               tasks_task.ref,
+                               tasks_task.subject,
+                               tasks_task.status_id,
+                               tasks_task.is_blocked,
+                               tasks_task.is_iocaine,
+                               tasks_task.user_story_id,
+                               tasks_task.milestone_id,
+                               tasks_task.assigned_to_id,
+                               tasks_task.created_date,
+                               tasks_task.modified_date,
+                               projects_taskstatus.is_closed
+                          FROM tasks_task
+                    INNER JOIN projects_taskstatus
+                            ON projects_taskstatus.id = tasks_task.status_id
+                         WHERE tasks_task.project_id = {tbl}.id
+                      ORDER BY tasks_task.us_order, tasks_task.ref
+                    ) t
+          """
+
+    sql = sql.format(tbl=model._meta.db_table)
+    queryset = queryset.extra(select={as_field: sql})
+    return queryset

--- a/tests/integration/test_project_relational_data_regression.py
+++ b/tests/integration/test_project_relational_data_regression.py
@@ -1,0 +1,393 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos INC
+
+"""
+Regression tests for the ?include= relational data feature.
+
+These tests guard against regressions by verifying:
+  1. Pre-existing API responses are not broken by the new fields.
+  2. The new `userstories` / `tasks` fields are always present in project
+     detail responses (empty list when not requested).
+  3. Private project access control is not weakened by the new feature.
+  4. The `include` param is silently ignored on list endpoints (no crash).
+  5. Unknown/garbage `include` values don't cause 500 errors.
+  6. Combining `include` with other existing query params keeps working.
+"""
+
+import pytest
+from django.urls import reverse
+
+from taiga.base.utils import json
+from taiga.projects.models import Project
+from taiga.projects.userstories.models import UserStory
+from taiga.projects.tasks.models import Task
+
+from .. import factories as f
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Regression: pre-existing fields must survive the new serializer additions
+# ---------------------------------------------------------------------------
+
+class TestExistingProjectDetailFieldsUnchanged:
+    """Ensure the new userstories/tasks fields don't remove or rename
+    anything that was in the response before this feature."""
+
+    REQUIRED_TOP_LEVEL_FIELDS = [
+        "id", "name", "slug", "description",
+        "created_date", "modified_date",
+        "owner", "members",
+        "is_private", "is_backlog_activated", "is_kanban_activated",
+        "is_wiki_activated", "is_issues_activated", "is_epics_activated",
+        "total_milestones", "total_story_points",
+        "anon_permissions", "public_permissions",
+        "is_featured", "is_looking_for_people",
+        "my_permissions", "i_am_owner", "i_am_admin", "i_am_member",
+        "tags", "tags_colors",
+        "epic_statuses", "us_statuses", "points",
+        "task_statuses", "issue_statuses", "issue_types",
+        "priorities", "severities",
+        "roles", "milestones",
+        # new fields must always be present
+        "userstories", "tasks",
+    ]
+
+    def test_all_required_fields_present_without_include(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url)
+
+        assert response.status_code == 200
+        for field in self.REQUIRED_TOP_LEVEL_FIELDS:
+            assert field in response.data, f"Field '{field}' missing from response"
+
+    def test_all_required_fields_present_with_include_userstories(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        f.UserStoryFactory.create(project=project)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": "userstories"})
+
+        assert response.status_code == 200
+        for field in self.REQUIRED_TOP_LEVEL_FIELDS:
+            assert field in response.data, f"Field '{field}' missing from response"
+
+    def test_all_required_fields_present_with_include_tasks(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": "tasks"})
+
+        assert response.status_code == 200
+        for field in self.REQUIRED_TOP_LEVEL_FIELDS:
+            assert field in response.data, f"Field '{field}' missing from response"
+
+
+# ---------------------------------------------------------------------------
+# Regression: userstories / tasks are always empty lists without the param
+# ---------------------------------------------------------------------------
+
+class TestNewFieldsDefaultToEmptyList:
+
+    def test_userstories_is_empty_list_by_default(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        f.UserStoryFactory.create(project=project)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url)  # no include= param
+
+        assert response.status_code == 200
+        assert response.data["userstories"] == []
+
+    def test_tasks_is_empty_list_by_default(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        us = f.UserStoryFactory.create(project=project)
+        f.TaskFactory.create(project=project, user_story=us)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url)
+
+        assert response.status_code == 200
+        assert response.data["tasks"] == []
+
+    def test_userstories_is_empty_list_when_only_tasks_included(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        f.UserStoryFactory.create(project=project)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": "tasks"})
+
+        assert response.status_code == 200
+        assert response.data["userstories"] == []
+
+    def test_tasks_is_empty_list_when_only_userstories_included(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        us = f.UserStoryFactory.create(project=project)
+        f.TaskFactory.create(project=project, user_story=us)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": "userstories"})
+
+        assert response.status_code == 200
+        assert response.data["tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: access control must not be weakened
+# ---------------------------------------------------------------------------
+
+class TestAccessControlNotWeakened:
+
+    def test_anonymous_cannot_access_private_project_with_include(self, client):
+        project = f.ProjectFactory.create(is_private=True)
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": "userstories,tasks"})
+
+        assert response.status_code == 401
+
+    def test_non_member_cannot_access_private_project_with_include(self, client):
+        owner = f.UserFactory.create()
+        other_user = f.UserFactory.create()
+        project = f.ProjectFactory.create(owner=owner, is_private=True)
+        f.MembershipFactory(user=owner, project=project, is_admin=True)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        client.login(other_user)
+        response = client.json.get(url, {"include": "userstories,tasks"})
+
+        assert response.status_code == 404
+
+    def test_member_can_access_private_project_with_include(self, client):
+        project = f.ProjectFactory.create(is_private=True)
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        client.login(project.owner)
+        response = client.json.get(url, {"include": "userstories,tasks"})
+
+        assert response.status_code == 200
+
+    def test_include_does_not_expose_other_projects_tasks(self, client):
+        """Regression guard: tasks from project B must never appear when
+        requesting project A with ?include=tasks."""
+        owner = f.UserFactory.create()
+        project_a = f.ProjectFactory.create(
+            owner=owner,
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        project_b = f.ProjectFactory.create(
+            owner=owner,
+            is_private=False,
+        )
+        f.MembershipFactory(user=owner, project=project_a, is_admin=True)
+        f.MembershipFactory(user=owner, project=project_b, is_admin=True)
+
+        us_b = f.UserStoryFactory.create(project=project_b)
+        task_b = f.TaskFactory.create(project=project_b, user_story=us_b)
+
+        url = reverse("projects-detail", kwargs={"pk": project_a.id})
+        response = client.json.get(url, {"include": "tasks"})
+
+        assert response.status_code == 200
+        returned_ids = {t["id"] for t in response.data["tasks"]}
+        assert task_b.id not in returned_ids
+
+    def test_include_does_not_expose_other_projects_userstories(self, client):
+        """Regression guard: user stories from project B must never appear
+        when requesting project A with ?include=userstories."""
+        owner = f.UserFactory.create()
+        project_a = f.ProjectFactory.create(
+            owner=owner,
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        project_b = f.ProjectFactory.create(owner=owner, is_private=False)
+        f.MembershipFactory(user=owner, project=project_a, is_admin=True)
+        f.MembershipFactory(user=owner, project=project_b, is_admin=True)
+
+        us_b = f.UserStoryFactory.create(project=project_b, subject="Secret story")
+
+        url = reverse("projects-detail", kwargs={"pk": project_a.id})
+        response = client.json.get(url, {"include": "userstories"})
+
+        assert response.status_code == 200
+        returned_ids = {u["id"] for u in response.data["userstories"]}
+        assert us_b.id not in returned_ids
+
+
+# ---------------------------------------------------------------------------
+# Regression: unknown / garbage include values must not cause 500 errors
+# ---------------------------------------------------------------------------
+
+class TestBadIncludeParamIsHarmless:
+
+    def test_unknown_include_value_returns_200(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": "nonexistent_relation"})
+
+        assert response.status_code == 200
+        assert response.data["userstories"] == []
+        assert response.data["tasks"] == []
+
+    def test_empty_include_value_returns_200(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": ""})
+
+        assert response.status_code == 200
+
+    def test_include_with_whitespace_is_handled(self, client):
+        project = f.ProjectFactory.create(
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        f.UserStoryFactory.create(project=project)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        response = client.json.get(url, {"include": " userstories , tasks "})
+
+        assert response.status_code == 200
+        # spaces stripped → both should activate
+        assert isinstance(response.data["userstories"], list)
+        assert isinstance(response.data["tasks"], list)
+
+
+# ---------------------------------------------------------------------------
+# Regression: project list endpoint must not crash with include param
+# ---------------------------------------------------------------------------
+
+class TestIncludeParamOnListEndpoint:
+
+    def test_list_endpoint_with_include_returns_200(self, client):
+        user = f.UserFactory.create()
+        f.ProjectFactory.create(
+            owner=user,
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        url = reverse("projects-list")
+
+        response = client.json.get(url, {"include": "userstories,tasks"})
+
+        # List uses ProjectSerializer (not ProjectDetailSerializer),
+        # so userstories/tasks are absent — but no 500 should occur.
+        assert response.status_code == 200
+
+    def test_by_slug_with_include_userstories(self, client):
+        project = f.ProjectFactory.create(is_private=True)
+        f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+        f.UserStoryFactory.create(project=project, subject="Slug story")
+        url = reverse("projects-by-slug")
+
+        client.login(project.owner)
+        response = client.json.get(url, {"slug": project.slug, "include": "userstories"})
+
+        assert response.status_code == 200
+        assert any(u["subject"] == "Slug story" for u in response.data["userstories"])
+
+
+# ---------------------------------------------------------------------------
+# Regression: combining include with existing query params
+# ---------------------------------------------------------------------------
+
+class TestIncludeCombinedWithOtherParams:
+
+    def test_include_with_slight_param_returns_200_without_extra_fields(self, client):
+        """slight=true uses ProjectLightSerializer which has no userstories/tasks.
+        The include param should be parsed but do nothing harmful."""
+        user = f.UserFactory.create()
+        project = f.ProjectFactory.create(
+            owner=user,
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        f.MembershipFactory(user=user, project=project, is_admin=True)
+        url = reverse("projects-list")
+
+        response = client.json.get(url, {"slight": "true", "include": "userstories"})
+
+        assert response.status_code == 200
+
+    def test_include_combined_with_member_filter(self, client):
+        user = f.UserFactory.create()
+        project = f.ProjectFactory.create(
+            owner=user,
+            is_private=False,
+            anon_permissions=["view_project"],
+            public_permissions=["view_project"],
+        )
+        role = f.RoleFactory.create(project=project, permissions=["view_project"])
+        f.MembershipFactory(user=user, project=project, role=role, is_admin=True)
+        f.UserStoryFactory.create(project=project)
+        url = reverse("projects-detail", kwargs={"pk": project.id})
+
+        client.login(user)
+        response = client.json.get(url, {"include": "userstories,tasks"})
+
+        assert response.status_code == 200
+        assert isinstance(response.data["userstories"], list)
+        assert isinstance(response.data["tasks"], list)

--- a/tests/integration/test_projects.py
+++ b/tests/integration/test_projects.py
@@ -2934,3 +2934,122 @@ def test_swimlane_userstory_statuses_creation_when_a_new_user_story_status_is_cr
 
     assert swimlane2.statuses.count() == 3
     assert swimlane2.statuses.all()[2].wip_limit is None
+
+
+######################################################
+# Tests: relational data include via ?include= param
+######################################################
+
+def test_get_project_detail_without_include_has_empty_relational_fields(client):
+    project = f.ProjectFactory.create(is_private=False,
+                                      anon_permissions=["view_project"],
+                                      public_permissions=["view_project"])
+    f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+
+    url = reverse("projects-detail", kwargs={"pk": project.id})
+    response = client.json.get(url)
+
+    assert response.status_code == 200
+    assert response.data["userstories"] == []
+    assert response.data["tasks"] == []
+
+
+def test_get_project_detail_with_include_userstories(client):
+    project = f.ProjectFactory.create(is_private=False,
+                                      anon_permissions=["view_project"],
+                                      public_permissions=["view_project"])
+    f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+    us1 = f.UserStoryFactory.create(project=project, subject="Story One")
+    us2 = f.UserStoryFactory.create(project=project, subject="Story Two")
+
+    url = reverse("projects-detail", kwargs={"pk": project.id})
+    response = client.json.get(url, {"include": "userstories"})
+
+    assert response.status_code == 200
+    returned_ids = {us["id"] for us in response.data["userstories"]}
+    assert us1.id in returned_ids
+    assert us2.id in returned_ids
+    # Each user story entry should carry the expected fields
+    first_us = next(us for us in response.data["userstories"] if us["id"] == us1.id)
+    assert first_us["subject"] == "Story One"
+    assert "ref" in first_us
+    assert "status_id" in first_us
+    assert "is_closed" in first_us
+    # tasks field should still be empty when tasks not included
+    assert response.data["tasks"] == []
+
+
+def test_get_project_detail_with_include_tasks(client):
+    project = f.ProjectFactory.create(is_private=False,
+                                      anon_permissions=["view_project"],
+                                      public_permissions=["view_project"])
+    f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+    us = f.UserStoryFactory.create(project=project)
+    task1 = f.TaskFactory.create(project=project, user_story=us, subject="Task Alpha")
+    task2 = f.TaskFactory.create(project=project, user_story=us, subject="Task Beta")
+
+    url = reverse("projects-detail", kwargs={"pk": project.id})
+    response = client.json.get(url, {"include": "tasks"})
+
+    assert response.status_code == 200
+    returned_ids = {t["id"] for t in response.data["tasks"]}
+    assert task1.id in returned_ids
+    assert task2.id in returned_ids
+    first_task = next(t for t in response.data["tasks"] if t["id"] == task1.id)
+    assert first_task["subject"] == "Task Alpha"
+    assert "ref" in first_task
+    assert "user_story_id" in first_task
+    assert "is_closed" in first_task
+    # userstories field should still be empty when not included
+    assert response.data["userstories"] == []
+
+
+def test_get_project_detail_with_include_userstories_and_tasks(client):
+    project = f.ProjectFactory.create(is_private=False,
+                                      anon_permissions=["view_project"],
+                                      public_permissions=["view_project"])
+    f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+    us = f.UserStoryFactory.create(project=project, subject="Combined Story")
+    task = f.TaskFactory.create(project=project, user_story=us, subject="Combined Task")
+
+    url = reverse("projects-detail", kwargs={"pk": project.id})
+    response = client.json.get(url, {"include": "userstories,tasks"})
+
+    assert response.status_code == 200
+    assert any(u["id"] == us.id for u in response.data["userstories"])
+    assert any(t["id"] == task.id for t in response.data["tasks"])
+
+
+def test_get_project_detail_include_userstories_empty_project(client):
+    project = f.ProjectFactory.create(is_private=False,
+                                      anon_permissions=["view_project"],
+                                      public_permissions=["view_project"])
+    f.MembershipFactory(user=project.owner, project=project, is_admin=True)
+
+    url = reverse("projects-detail", kwargs={"pk": project.id})
+    response = client.json.get(url, {"include": "userstories"})
+
+    assert response.status_code == 200
+    assert response.data["userstories"] == []
+
+
+def test_get_project_detail_include_is_scoped_to_own_project(client):
+    project1 = f.ProjectFactory.create(is_private=False,
+                                       anon_permissions=["view_project"],
+                                       public_permissions=["view_project"])
+    project2 = f.ProjectFactory.create(is_private=False,
+                                       anon_permissions=["view_project"],
+                                       public_permissions=["view_project"])
+    f.MembershipFactory(user=project1.owner, project=project1, is_admin=True)
+    f.MembershipFactory(user=project2.owner, project=project2, is_admin=True)
+
+    us_in_project1 = f.UserStoryFactory.create(project=project1, subject="P1 Story")
+    us_in_project2 = f.UserStoryFactory.create(project=project2, subject="P2 Story")
+
+    url = reverse("projects-detail", kwargs={"pk": project1.id})
+    response = client.json.get(url, {"include": "userstories"})
+
+    assert response.status_code == 200
+    returned_ids = {us["id"] for us in response.data["userstories"]}
+    assert us_in_project1.id in returned_ids
+    assert us_in_project2.id not in returned_ids

--- a/tests/unit/test_project_relational_utils.py
+++ b/tests/unit/test_project_relational_utils.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos INC
+
+"""
+Unit tests for the relational data utilities:
+  taiga.projects.utils.attach_userstories_to_project
+  taiga.projects.utils.attach_tasks_to_project
+
+and the ProjectDetailSerializer methods:
+  get_userstories
+  get_tasks
+
+Each test isolates a single function or method, using mocks or minimal db
+objects only as needed.
+"""
+
+import pytest
+from unittest import mock
+
+from taiga.projects.utils import attach_userstories_to_project, attach_tasks_to_project
+from taiga.projects.serializers import ProjectDetailSerializer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_queryset_mock(model_db_table="projects_project"):
+    """Return a mock queryset whose .model._meta.db_table is predictable."""
+    qs = mock.MagicMock()
+    qs.model._meta.db_table = model_db_table
+    # .extra(select=...) must return the same mock so callers can chain
+    qs.extra.return_value = qs
+    return qs
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: attach_userstories_to_project
+# ---------------------------------------------------------------------------
+
+class TestAttachUserstoriesToProject:
+    def test_returns_queryset(self):
+        qs = _make_queryset_mock()
+        result = attach_userstories_to_project(qs)
+        assert result is qs
+
+    def test_calls_extra_with_userstories_attr_key(self):
+        qs = _make_queryset_mock()
+        attach_userstories_to_project(qs)
+        qs.extra.assert_called_once()
+        call_kwargs = qs.extra.call_args
+        select_dict = call_kwargs[1].get("select") or call_kwargs[0][0]
+        assert "userstories_attr" in select_dict
+
+    def test_custom_as_field_name_is_used(self):
+        qs = _make_queryset_mock()
+        attach_userstories_to_project(qs, as_field="custom_us")
+        select_dict = qs.extra.call_args[1]["select"]
+        assert "custom_us" in select_dict
+
+    def test_sql_references_userstories_table(self):
+        qs = _make_queryset_mock()
+        attach_userstories_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["userstories_attr"]
+        assert "userstories_userstory" in sql
+
+    def test_sql_filters_by_project_id(self):
+        qs = _make_queryset_mock("projects_project")
+        attach_userstories_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["userstories_attr"]
+        assert "projects_project.id" in sql
+
+    def test_sql_contains_required_columns(self):
+        qs = _make_queryset_mock()
+        attach_userstories_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["userstories_attr"]
+        for col in ("ref", "subject", "status_id", "is_closed", "backlog_order",
+                    "sprint_order", "kanban_order", "milestone_id",
+                    "assigned_to_id", "is_blocked"):
+            assert col in sql, f"Expected column '{col}' in SQL"
+
+    def test_sql_uses_correct_db_table_name(self):
+        qs = _make_queryset_mock("custom_schema_project")
+        attach_userstories_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["userstories_attr"]
+        assert "custom_schema_project.id" in sql
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: attach_tasks_to_project
+# ---------------------------------------------------------------------------
+
+class TestAttachTasksToProject:
+    def test_returns_queryset(self):
+        qs = _make_queryset_mock()
+        result = attach_tasks_to_project(qs)
+        assert result is qs
+
+    def test_calls_extra_with_tasks_attr_key(self):
+        qs = _make_queryset_mock()
+        attach_tasks_to_project(qs)
+        qs.extra.assert_called_once()
+        select_dict = qs.extra.call_args[1]["select"]
+        assert "tasks_attr" in select_dict
+
+    def test_custom_as_field_name_is_used(self):
+        qs = _make_queryset_mock()
+        attach_tasks_to_project(qs, as_field="my_tasks")
+        select_dict = qs.extra.call_args[1]["select"]
+        assert "my_tasks" in select_dict
+
+    def test_sql_references_tasks_table(self):
+        qs = _make_queryset_mock()
+        attach_tasks_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["tasks_attr"]
+        assert "tasks_task" in sql
+
+    def test_sql_joins_taskstatus_for_is_closed(self):
+        qs = _make_queryset_mock()
+        attach_tasks_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["tasks_attr"]
+        assert "projects_taskstatus" in sql
+        assert "is_closed" in sql
+
+    def test_sql_filters_by_project_id(self):
+        qs = _make_queryset_mock("projects_project")
+        attach_tasks_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["tasks_attr"]
+        assert "projects_project.id" in sql
+
+    def test_sql_contains_required_columns(self):
+        qs = _make_queryset_mock()
+        attach_tasks_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["tasks_attr"]
+        for col in ("ref", "subject", "status_id", "is_blocked",
+                    "is_iocaine", "user_story_id", "milestone_id",
+                    "assigned_to_id"):
+            assert col in sql, f"Expected column '{col}' in SQL"
+
+    def test_sql_uses_correct_db_table_name(self):
+        qs = _make_queryset_mock("other_schema_project")
+        attach_tasks_to_project(qs)
+        sql = qs.extra.call_args[1]["select"]["tasks_attr"]
+        assert "other_schema_project.id" in sql
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: ProjectDetailSerializer.get_userstories / get_tasks
+# ---------------------------------------------------------------------------
+
+class TestProjectDetailSerializerGetUserstories:
+    def _make_obj(self, include=False, attr=None):
+        obj = mock.MagicMock()
+        obj.include_userstories = include
+        obj.userstories_attr = attr
+        return obj
+
+    def test_returns_empty_list_when_include_flag_not_set(self):
+        serializer = ProjectDetailSerializer()
+        obj = self._make_obj(include=False)
+        assert serializer.get_userstories(obj) == []
+
+    def test_returns_empty_list_when_include_flag_is_false(self):
+        serializer = ProjectDetailSerializer()
+        obj = self._make_obj(include=False, attr=[{"id": 1}])
+        assert serializer.get_userstories(obj) == []
+
+    def test_returns_attr_when_include_flag_is_true(self):
+        serializer = ProjectDetailSerializer()
+        data = [{"id": 1, "subject": "Story"}, {"id": 2, "subject": "Story 2"}]
+        obj = self._make_obj(include=True, attr=data)
+        assert serializer.get_userstories(obj) == data
+
+    def test_returns_empty_list_when_attr_is_none_even_with_include(self):
+        serializer = ProjectDetailSerializer()
+        obj = self._make_obj(include=True, attr=None)
+        assert serializer.get_userstories(obj) == []
+
+    def test_raises_assertion_when_include_set_but_attr_missing(self):
+        serializer = ProjectDetailSerializer()
+        obj = mock.MagicMock(spec=[])          # no userstories_attr at all
+        obj.include_userstories = True
+        with pytest.raises(AssertionError):
+            serializer.get_userstories(obj)
+
+
+class TestProjectDetailSerializerGetTasks:
+    def _make_obj(self, include=False, attr=None):
+        obj = mock.MagicMock()
+        obj.include_tasks = include
+        obj.tasks_attr = attr
+        return obj
+
+    def test_returns_empty_list_when_include_flag_not_set(self):
+        serializer = ProjectDetailSerializer()
+        obj = self._make_obj(include=False)
+        assert serializer.get_tasks(obj) == []
+
+    def test_returns_empty_list_when_include_flag_is_false(self):
+        serializer = ProjectDetailSerializer()
+        obj = self._make_obj(include=False, attr=[{"id": 10}])
+        assert serializer.get_tasks(obj) == []
+
+    def test_returns_attr_when_include_flag_is_true(self):
+        serializer = ProjectDetailSerializer()
+        data = [{"id": 10, "subject": "Task A"}, {"id": 11, "subject": "Task B"}]
+        obj = self._make_obj(include=True, attr=data)
+        assert serializer.get_tasks(obj) == data
+
+    def test_returns_empty_list_when_attr_is_none_even_with_include(self):
+        serializer = ProjectDetailSerializer()
+        obj = self._make_obj(include=True, attr=None)
+        assert serializer.get_tasks(obj) == []
+
+    def test_raises_assertion_when_include_set_but_attr_missing(self):
+        serializer = ProjectDetailSerializer()
+        obj = mock.MagicMock(spec=[])
+        obj.include_tasks = True
+        with pytest.raises(AssertionError):
+            serializer.get_tasks(obj)


### PR DESCRIPTION
Added ?include=userstories,tasks support to GET /api/v1/projects/{id}, allowing a project's user stories and tasks to be embedded directly in the API response. Changes touch utils.py, serializers.py, and api.py. Covered by unit tests, integration tests, and a regression test file.

This change request address [FR] #115

