### PR TITLE
Fix: migrate from Django 3.2 (EOL) to Django 5.2 LTS ([Bug] #195)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,7 @@
 DJANGO_SETTINGS_MODULE = tests.config
 filterwarnings =
     # Django
-    ignore::django.utils.deprecation.RemovedInDjango40Warning
-    ignore::django.utils.deprecation.RemovedInDjango41Warning
+    ignore::django.utils.deprecation.RemovedInDjango60Warning
     ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
     ignore:Use setlocale\(\), getencoding\(\) and getlocale\(\) instead:DeprecationWarning
     # PyJWT

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 # Main
-Django>=3.2.19,<4
+Django>=5.2,<6
 celery
 gunicorn
-psycopg2<2.10  # required by django, 2.9.10 was the latest
+psycopg2>=2.9.1  # Django 5.x requires psycopg2 >= 2.9.1
 redis
 
 # Third party by Kaleidos
@@ -12,13 +12,13 @@ django-sr>=0.0.4
 djmail>=2.0.0
 
 # Other third party
-bleach<5 # v6.0.0 has backwards incompatible changes https://github.com/mozilla/bleach/blob/main/CHANGES#L44
+bleach<6 # v6.0.0 removed module-level ALLOWED_TAGS/ALLOWED_ATTRIBUTES used in mdrender/service.py
 diff-match-patch
 django-ipware>7
 django-jinja
-django-picklefield<3.3.0 # 3.3.0 dropped support for Django 3.2
+django-picklefield>=3.3.0 # >=3.3.0 required; older versions only supported Django 3.2
 django-pglocks
-easy-thumbnails<2.9 # 2.9 released after Django 3.2 LTS EOL
+easy-thumbnails>=2.10 # 2.10+ required for Django 5.x support (2.9 still used removed get_storage_class)
 netaddr
 premailer>=3.10
 psd-tools>=1.9.18,<1.10.0 # https://psd-tools.readthedocs.io/en/latest/migration.html#migrating-to-1-10

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ defusedxml==0.7.1
     # via cairosvg
 diff-match-patch==20241021
     # via -r requirements.in
-django==3.2.25
+django==5.2.1
     # via
     #   -r requirements.in
     #   django-jinja
@@ -79,7 +79,7 @@ django-jinja==2.11.0
     # via -r requirements.in
 django-pglocks==1.0.4
     # via -r requirements.in
-django-picklefield==3.2
+django-picklefield==3.3.0
     # via -r requirements.in
 django-sampledatahelper==0.5
     # via -r requirements.in
@@ -91,7 +91,7 @@ djmail==2.0.0
     # via -r requirements.in
 docopt==0.6.2
     # via psd-tools
-easy-thumbnails==2.8.5
+easy-thumbnails==2.10.1
     # via -r requirements.in
 gunicorn==23.0.0
     # via -r requirements.in
@@ -156,7 +156,7 @@ prompt-toolkit==3.0.52
 psd-tools==1.9.34
     # via -r requirements.in
 psycopg2==2.9.11
-    # via -r requirements.in
+    # via -r requirements.in (Django 5.x requires >= 2.9.1)
 pycparser==2.23
     # via cffi
 pygments==2.19.2

--- a/settings/common.py
+++ b/settings/common.py
@@ -73,7 +73,6 @@ USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Errors report configuration
-SEND_BROKEN_LINK_EMAILS = True
 IGNORABLE_404_ENDS = (".php", ".cgi")
 IGNORABLE_404_STARTS = ("/phpmyadmin/",)
 

--- a/taiga/auth/utils.py
+++ b/taiga/auth/utils.py
@@ -30,22 +30,24 @@
 #   SOFTWARE.
 
 from calendar import timegm
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.conf import settings
 from django.utils.functional import lazy
-from django.utils.timezone import is_naive, make_aware, utc
+from django.utils.timezone import is_naive, make_aware
+
+_utc = timezone.utc
 
 
 def make_utc(dt):
     if settings.USE_TZ and is_naive(dt):
-        return make_aware(dt, timezone=utc)
+        return make_aware(dt, timezone=_utc)
 
     return dt
 
 
 def aware_utcnow():
-    return make_utc(datetime.utcnow())
+    return make_utc(datetime.now(tz=_utc).replace(tzinfo=None))
 
 
 def datetime_to_epoch(dt):
@@ -53,7 +55,7 @@ def datetime_to_epoch(dt):
 
 
 def datetime_from_epoch(ts):
-    return make_utc(datetime.utcfromtimestamp(ts))
+    return make_utc(datetime.fromtimestamp(ts, tz=_utc).replace(tzinfo=None))
 
 
 def format_lazy(s, *args, **kwargs):

--- a/taiga/base/api/parsers.py
+++ b/taiga/base/api/parsers.py
@@ -41,7 +41,9 @@ from django.conf import settings
 from django.core.files.uploadhandler import StopFutureHandlers
 from django.http import QueryDict
 from django.http.multipartparser import MultiPartParser as DjangoMultiPartParser
-from django.http.multipartparser import MultiPartParserError, parse_header, ChunkIter
+from django.http.multipartparser import MultiPartParserError, ChunkIter
+
+from taiga.base.api.utils.mediatypes import parse_header
 
 import six
 

--- a/taiga/base/api/renderers.py
+++ b/taiga/base/api/renderers.py
@@ -41,10 +41,11 @@ REST framework also provides an HTML renderer the renders the browsable API.
 """
 
 from django.core.exceptions import ImproperlyConfigured
-from django.http.multipartparser import parse_header
 from django.template import RequestContext, loader, Template
 from django.test.client import encode_multipart
 import six
+
+from taiga.base.api.utils.mediatypes import parse_header
 
 from .utils import encoders
 

--- a/taiga/base/api/request.py
+++ b/taiga/base/api/request.py
@@ -43,9 +43,10 @@ The wrapped request then offers a richer API, in particular :
 """
 from django.conf import settings
 from django.http import QueryDict
-from django.http.multipartparser import parse_header
 from django.utils.datastructures import MultiValueDict
 import six
+
+from taiga.base.api.utils.mediatypes import parse_header
 
 from taiga.base import exceptions
 

--- a/taiga/base/api/utils/mediatypes.py
+++ b/taiga/base/api/utils/mediatypes.py
@@ -36,9 +36,24 @@ Handling of media types, as found in HTTP Content-Type and Accept headers.
 
 See http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7
 """
-from django.http.multipartparser import parse_header
-
 from taiga.base.api import HTTP_HEADER_ENCODING
+
+from email.message import Message as _Message
+
+
+def parse_header(line):
+    """Parse a Content-Type-like header into (main_value, params dict).
+
+    Replaces django.http.multipartparser.parse_header which was removed in Django 5.0.
+    """
+    if isinstance(line, bytes):
+        line = line.decode("latin-1")
+    msg = _Message()
+    msg["content-type"] = line
+    params = msg.get_params()
+    if not params:
+        return line.split(";")[0].strip(), {}
+    return params[0][0], {k: v for k, v in params[1:]}
 
 
 def media_type_matches(lhs, rhs):

--- a/taiga/projects/attachments/models.py
+++ b/taiga/projects/attachments/models.py
@@ -73,7 +73,9 @@ class Attachment(models.Model):
         verbose_name = "attachment"
         verbose_name_plural = "attachments"
         ordering = ["project", "created_date", "id"]
-        index_together = [("content_type", "object_id")]
+        indexes = [
+            models.Index(fields=["content_type", "object_id"]),
+        ]
 
     def __init__(self, *args, **kwargs):
         super(Attachment, self).__init__(*args, **kwargs)

--- a/taiga/projects/custom_attributes/models.py
+++ b/taiga/projects/custom_attributes/models.py
@@ -107,7 +107,9 @@ class EpicCustomAttributesValues(AbstractCustomAttributesValues):
     class Meta(AbstractCustomAttributesValues.Meta):
         verbose_name = "epic custom attributes values"
         verbose_name_plural = "epic custom attributes values"
-        index_together = [("epic",)]
+        indexes = [
+            models.Index(fields=["epic"]),
+        ]
 
     @property
     def project(self):
@@ -128,7 +130,9 @@ class UserStoryCustomAttributesValues(AbstractCustomAttributesValues):
     class Meta(AbstractCustomAttributesValues.Meta):
         verbose_name = "user story custom attributes values"
         verbose_name_plural = "user story custom attributes values"
-        index_together = [("user_story",)]
+        indexes = [
+            models.Index(fields=["user_story"]),
+        ]
 
     @property
     def project(self):
@@ -149,7 +153,9 @@ class TaskCustomAttributesValues(AbstractCustomAttributesValues):
     class Meta(AbstractCustomAttributesValues.Meta):
         verbose_name = "task custom attributes values"
         verbose_name_plural = "task custom attributes values"
-        index_together = [("task",)]
+        indexes = [
+            models.Index(fields=["task"]),
+        ]
 
     @property
     def project(self):
@@ -170,7 +176,9 @@ class IssueCustomAttributesValues(AbstractCustomAttributesValues):
     class Meta(AbstractCustomAttributesValues.Meta):
         verbose_name = "issue custom attributes values"
         verbose_name_plural = "issue custom attributes values"
-        index_together = [("issue",)]
+        indexes = [
+            models.Index(fields=["issue"]),
+        ]
 
     @property
     def project(self):

--- a/taiga/projects/migrations/0030_auto_20151128_0757.py
+++ b/taiga/projects/migrations/0030_auto_20151128_0757.py
@@ -8,7 +8,6 @@
 from __future__ import unicode_literals
 
 from django.db import connection, migrations, models
-from django.utils.timezone import utc
 import datetime
 
 
@@ -165,7 +164,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='project',
             name='totals_updated_datetime',
-            field=models.DateTimeField(default=datetime.datetime(2015, 11, 28, 7, 57, 11, 743976, tzinfo=utc), auto_now_add=True, verbose_name='updated date time', db_index=True),
+            field=models.DateTimeField(default=datetime.datetime(2015, 11, 28, 7, 57, 11, 743976, tzinfo=datetime.timezone.utc), auto_now_add=True, verbose_name='updated date time', db_index=True),
             preserve_default=False,
         ),
         migrations.RunPython(update_totals),

--- a/taiga/projects/models.py
+++ b/taiga/projects/models.py
@@ -293,8 +293,8 @@ class Project(ProjectDefaults, TaggedMixin, TagsColorsMixin, models.Model):
         verbose_name = "project"
         verbose_name_plural = "projects"
         ordering = ["name", "id"]
-        index_together = [
-            ["name", "id"],
+        indexes = [
+            models.Index(fields=["name", "id"]),
         ]
 
     def __str__(self):

--- a/taiga/projects/votes/migrations/0002_auto_20150805_1600.py
+++ b/taiga/projects/votes/migrations/0002_auto_20150805_1600.py
@@ -8,7 +8,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-from django.utils.timezone import utc
 from django.conf import settings
 import datetime
 
@@ -23,7 +22,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='vote',
             name='created_date',
-            field=models.DateTimeField(auto_now_add=True, default=datetime.datetime(2015, 8, 5, 16, 0, 40, 158374, tzinfo=utc), verbose_name='created date'),
+            field=models.DateTimeField(auto_now_add=True, default=datetime.datetime(2015, 8, 5, 16, 0, 40, 158374, tzinfo=datetime.timezone.utc), verbose_name='created date'),
             preserve_default=False,
         ),
         migrations.AlterField(

--- a/tests/unit/test_django5_upgrade.py
+++ b/tests/unit/test_django5_upgrade.py
@@ -1,0 +1,274 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos INC
+
+"""
+Tests verifying Django 5.x compatibility.
+
+Covers:
+ - Django version >= 5.0 is in use.
+ - Migration files no longer import the removed django.utils.timezone.utc.
+ - SEND_BROKEN_LINK_EMAILS (removed in Django 4.0) is absent from settings.
+ - Migration files use datetime.timezone.utc for timezone-aware defaults.
+ - django.http.multipartparser.parse_header compat shim works correctly (removed in Django 5.0).
+ - Model Meta no longer uses index_together (removed in Django 5.1).
+ - taiga.auth.utils no longer imports the removed django.utils.timezone.utc.
+"""
+
+import ast
+import datetime
+import importlib
+import sys
+
+import django
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Django version guard
+# ---------------------------------------------------------------------------
+
+def test_django_version_is_5_or_higher():
+    """Regression: repo must run on Django >= 5 (3.2 reached EOL April 2024)."""
+    major = django.VERSION[0]
+    assert major >= 5, (
+        f"Django {django.get_version()} is installed but >= 5.0 is required. "
+        "Django 3.2 reached end-of-life in April 2024."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Migration file regressions (django.utils.timezone.utc removed in 5.0)
+# ---------------------------------------------------------------------------
+
+MIGRATION_FILES_UNDER_TEST = [
+    "taiga.projects.votes.migrations.0002_auto_20150805_1600",
+    "taiga.projects.migrations.0030_auto_20151128_0757",
+]
+
+
+@pytest.mark.parametrize("module_path", MIGRATION_FILES_UNDER_TEST)
+def test_migration_does_not_import_removed_django_timezone_utc(module_path):
+    """
+    Regression: django.utils.timezone.utc was removed in Django 5.0.
+    Migration files must not import it.
+    """
+    module = importlib.import_module(module_path)
+    source_file = module.__file__
+
+    with open(source_file, encoding="utf-8") as fh:
+        source = fh.read()
+
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "django.utils.timezone":
+                imported_names = [alias.name for alias in node.names]
+                assert "utc" not in imported_names, (
+                    f"{source_file}: found 'from django.utils.timezone import utc' "
+                    "which was removed in Django 5.0. "
+                    "Use datetime.timezone.utc instead."
+                )
+
+
+@pytest.mark.parametrize("module_path", MIGRATION_FILES_UNDER_TEST)
+def test_migration_module_imports_cleanly(module_path):
+    """The migration module must be importable without errors under Django 5.x."""
+    # Force a fresh import to surface any ImportError at collection time.
+    if module_path in sys.modules:
+        del sys.modules[module_path]
+    try:
+        importlib.import_module(module_path)
+    except ImportError as exc:
+        pytest.fail(f"{module_path} failed to import: {exc}")
+
+
+@pytest.mark.parametrize("module_path", MIGRATION_FILES_UNDER_TEST)
+def test_migration_default_datetimes_use_stdlib_utc(module_path):
+    """
+    DateTimeField defaults that embed a fixed datetime must use
+    datetime.timezone.utc (stdlib), not the removed django.utils.timezone.utc.
+    """
+    module = importlib.import_module(module_path)
+    migration = module.Migration
+
+    for operation in migration.operations:
+        field = getattr(operation, "field", None)
+        if field is None:
+            continue
+        default = field.default
+        if isinstance(default, datetime.datetime) and default.tzinfo is not None:
+            assert default.tzinfo is datetime.timezone.utc, (
+                f"{module_path}: field default {default!r} uses tzinfo="
+                f"{default.tzinfo!r} instead of datetime.timezone.utc."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Settings regression
+# ---------------------------------------------------------------------------
+
+def test_settings_does_not_contain_removed_send_broken_link_emails():
+    """
+    Regression: SEND_BROKEN_LINK_EMAILS was removed in Django 4.0.
+    It must not appear in the project settings to avoid confusion.
+    """
+    from django.conf import settings as django_settings
+
+    assert not hasattr(django_settings, "SEND_BROKEN_LINK_EMAILS"), (
+        "SEND_BROKEN_LINK_EMAILS was removed from Django in 4.0 "
+        "and must be removed from settings/common.py."
+    )
+
+
+def test_settings_common_py_does_not_reference_send_broken_link_emails():
+    """
+    Source-level check: the literal string must not appear in settings/common.py,
+    preventing accidental re-introduction.
+    """
+    import os
+
+    settings_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "settings",
+        "common.py",
+    )
+    with open(settings_path, encoding="utf-8") as fh:
+        content = fh.read()
+
+    assert "SEND_BROKEN_LINK_EMAILS" not in content, (
+        "settings/common.py still references SEND_BROKEN_LINK_EMAILS "
+        "which was removed in Django 4.0."
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse_header compat shim (django.http.multipartparser.parse_header removed in 5.0)
+# ---------------------------------------------------------------------------
+
+def test_parse_header_compat_shim_basic():
+    """
+    Regression: parse_header was removed from django.http.multipartparser in
+    Django 5.0. The compat shim must parse a simple content-type header correctly.
+    """
+    from taiga.base.api.utils.mediatypes import _MediaType
+
+    mt = _MediaType("application/json; charset=utf-8")
+    assert mt.main_type == "application"
+    assert mt.sub_type == "json"
+    assert mt.params.get("charset") == "utf-8"
+
+
+def test_parse_header_compat_shim_no_params():
+    """Compat shim handles headers with no parameters."""
+    from taiga.base.api.utils.mediatypes import _MediaType
+
+    mt = _MediaType("application/json")
+    assert mt.main_type == "application"
+    assert mt.sub_type == "json"
+    assert mt.params == {}
+
+
+def test_parse_header_compat_shim_wildcard():
+    """Compat shim handles wildcard media types."""
+    from taiga.base.api.utils.mediatypes import _MediaType
+
+    mt = _MediaType("*/*")
+    assert mt.main_type == "*"
+    assert mt.sub_type == "*"
+
+
+def test_media_type_matches_exact():
+    """media_type_matches returns True for identical types."""
+    from taiga.base.api.utils.mediatypes import media_type_matches
+
+    assert media_type_matches("application/json", "application/json") is True
+
+
+def test_media_type_matches_wildcard():
+    """media_type_matches returns True when rhs is a wildcard."""
+    from taiga.base.api.utils.mediatypes import media_type_matches
+
+    assert media_type_matches("application/json", "*/*") is True
+
+
+def test_is_form_media_type():
+    """is_form_media_type works correctly after the parse_header shim."""
+    from taiga.base.api.request import is_form_media_type
+
+    assert is_form_media_type("application/x-www-form-urlencoded") is True
+    assert is_form_media_type("multipart/form-data") is True
+    assert is_form_media_type("application/json") is False
+
+
+# ---------------------------------------------------------------------------
+# index_together removed from model Meta (Django 5.1)
+# ---------------------------------------------------------------------------
+
+INDEX_TOGETHER_MODEL_FILES = [
+    "taiga/projects/attachments/models.py",
+    "taiga/projects/models.py",
+    "taiga/projects/custom_attributes/models.py",
+]
+
+
+@pytest.mark.parametrize("rel_path", INDEX_TOGETHER_MODEL_FILES)
+def test_model_does_not_use_index_together(rel_path):
+    """
+    Regression: index_together was removed from Django model Meta in 5.1.
+    Model files must use indexes = [models.Index(...)] instead.
+    """
+    import os
+
+    base = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    abs_path = os.path.join(base, rel_path)
+
+    with open(abs_path, encoding="utf-8") as fh:
+        source = fh.read()
+
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "Meta":
+            for item in node.body:
+                if isinstance(item, ast.Assign):
+                    for target in item.targets:
+                        if isinstance(target, ast.Name) and target.id == "index_together":
+                            pytest.fail(
+                                f"{abs_path}: class Meta still uses 'index_together' "
+                                "which was removed in Django 5.1. "
+                                "Use 'indexes = [models.Index(...)]' instead."
+                            )
+
+
+# ---------------------------------------------------------------------------
+# taiga.auth.utils must not import removed django.utils.timezone.utc
+# ---------------------------------------------------------------------------
+
+def test_auth_utils_does_not_import_removed_utc():
+    """
+    Regression: django.utils.timezone.utc was removed in Django 5.0.
+    taiga/auth/utils.py must not import it.
+    """
+    import os
+
+    base = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    abs_path = os.path.join(base, "taiga", "auth", "utils.py")
+
+    with open(abs_path, encoding="utf-8") as fh:
+        source = fh.read()
+
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "django.utils.timezone":
+                imported_names = [alias.name for alias in node.names]
+                assert "utc" not in imported_names, (
+                    f"{abs_path}: imports 'utc' from 'django.utils.timezone' "
+                    "which was removed in Django 5.0. "
+                    "Use datetime.timezone.utc instead."
+                )


### PR DESCRIPTION
Django 3.2 reached end-of-life in April 2024 and no longer receives security updates. This PR upgrades to Django 5.2 LTS and fixes all breaking changes encountered.

This change request addresses [Bug] #195