### PR TITLE
fix: prevent type mismatch when deleting empty swimlane (#197)

### DIFF
--- a/taiga/projects/services/bulk_update_order.py
+++ b/taiga/projects/services/bulk_update_order.py
@@ -287,6 +287,9 @@ def update_order_and_swimlane(swimlane_to_be_deleted, move_to_swimlane):
     new_indexes = range(0, len(ordered_uss_ids))
     data = list(zip(ordered_swimlane_ids, ordered_uss_ids, new_indexes))
 
+    if not data:
+        return
+
     with connection.cursor() as curs:
         execute_values(curs,
                        """
@@ -295,4 +298,5 @@ def update_order_and_swimlane(swimlane_to_be_deleted, move_to_swimlane):
                            swimlane_id = tmp.sid
                        FROM (VALUES %s) AS tmp (sid, ussid, new_order)
                        WHERE tmp.ussid = userstories_userstory.id""",
-                       data)
+                       data,
+                       template="(%s::integer, %s, %s)")

--- a/taiga/projects/services/bulk_update_order.py
+++ b/taiga/projects/services/bulk_update_order.py
@@ -299,4 +299,4 @@ def update_order_and_swimlane(swimlane_to_be_deleted, move_to_swimlane):
                        FROM (VALUES %s) AS tmp (sid, ussid, new_order)
                        WHERE tmp.ussid = userstories_userstory.id""",
                        data,
-                       template="(%s::integer, %s, %s)")
+                       template="(%s::integer, %s::integer, %s::integer)")


### PR DESCRIPTION
## Problem

Deleting a swimlane that contains no user stories produces a 500 Internal Server Error:

```
django.db.utils.ProgrammingError: column "swimlane_id" is of type integer but expression is of type text
LINE 4:                            swimlane_id = tmp.sid
```

The error originates in `update_order_and_swimlane` (`bulk_update_order.py`). When the deleted swimlane is empty, all `sid` values in the bulk update data can be `None`. PostgreSQL cannot infer the type of a `VALUES` column that is entirely `NULL` and defaults to `text`, which mismatches the `integer` `swimlane_id` column.

## Fix

Two changes in `update_order_and_swimlane`:

1. Early return when `data` is empty (no user stories to reorder).
2. Added `template="(%s::integer, %s, %s)"` to `execute_values` so PostgreSQL resolves `sid` as `integer` even when all values are `NULL`.

Fixes #197