### PR TITLE
Fix typo in incorrect credentials error message

### DIFF
--- a/taiga/locale/ar/LC_MESSAGES/django.po
+++ b/taiga/locale/ar/LC_MESSAGES/django.po
@@ -4482,7 +4482,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/ca/LC_MESSAGES/django.po
+++ b/taiga/locale/ca/LC_MESSAGES/django.po
@@ -4542,7 +4542,7 @@ msgid "permissions"
 msgstr "permissos"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/da/LC_MESSAGES/django.po
+++ b/taiga/locale/da/LC_MESSAGES/django.po
@@ -4466,7 +4466,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/de/LC_MESSAGES/django.po
+++ b/taiga/locale/de/LC_MESSAGES/django.po
@@ -5370,7 +5370,7 @@ msgid "permissions"
 msgstr "Berechtigungen"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Benutzername oder Passwort stimmen mit keinem Benutzer überein."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/en/LC_MESSAGES/django.po
+++ b/taiga/locale/en/LC_MESSAGES/django.po
@@ -4466,7 +4466,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/es/LC_MESSAGES/django.po
+++ b/taiga/locale/es/LC_MESSAGES/django.po
@@ -5328,7 +5328,7 @@ msgid "permissions"
 msgstr "permisos"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Nombre de usuario o contraseña inválidos."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/eu/LC_MESSAGES/django.po
+++ b/taiga/locale/eu/LC_MESSAGES/django.po
@@ -5062,7 +5062,7 @@ msgid "permissions"
 msgstr "baimenak"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Erabiltzaile izena edo pasahitza ez datoz bat erabiltzaile honekin."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/fa/LC_MESSAGES/django.po
+++ b/taiga/locale/fa/LC_MESSAGES/django.po
@@ -4721,7 +4721,7 @@ msgid "permissions"
 msgstr "دسترسی‌ها"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "نام کاربری یا رمز عبور اشتباه است"
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/fi/LC_MESSAGES/django.po
+++ b/taiga/locale/fi/LC_MESSAGES/django.po
@@ -4581,7 +4581,7 @@ msgid "permissions"
 msgstr "oikeudet"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Käyttäjätunnus tai salasana eivät ole oikein."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/fr/LC_MESSAGES/django.po
+++ b/taiga/locale/fr/LC_MESSAGES/django.po
@@ -5350,7 +5350,7 @@ msgid "permissions"
 msgstr "permissions"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Aucun utilisateur avec ce nom ou ce mot de passe."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/he/LC_MESSAGES/django.po
+++ b/taiga/locale/he/LC_MESSAGES/django.po
@@ -4477,7 +4477,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/hu/LC_MESSAGES/django.po
+++ b/taiga/locale/hu/LC_MESSAGES/django.po
@@ -4464,7 +4464,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/id/LC_MESSAGES/django.po
+++ b/taiga/locale/id/LC_MESSAGES/django.po
@@ -4491,7 +4491,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/it/LC_MESSAGES/django.po
+++ b/taiga/locale/it/LC_MESSAGES/django.po
@@ -4777,7 +4777,7 @@ msgid "permissions"
 msgstr "permessi"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Il nome utente o la password non corrispondono all'utente."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/ja/LC_MESSAGES/django.po
+++ b/taiga/locale/ja/LC_MESSAGES/django.po
@@ -4557,7 +4557,7 @@ msgid "permissions"
 msgstr "アクセス権"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/ko/LC_MESSAGES/django.po
+++ b/taiga/locale/ko/LC_MESSAGES/django.po
@@ -4859,7 +4859,7 @@ msgid "permissions"
 msgstr "권한"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "아이디 또는 비밀번호가 올바르지 않습니다."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/lv/LC_MESSAGES/django.po
+++ b/taiga/locale/lv/LC_MESSAGES/django.po
@@ -4732,7 +4732,7 @@ msgid "permissions"
 msgstr "atļaujas"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Lietotājvārds vai parole neatbilst lietotājam."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/nb/LC_MESSAGES/django.po
+++ b/taiga/locale/nb/LC_MESSAGES/django.po
@@ -4553,7 +4553,7 @@ msgid "permissions"
 msgstr "rettigheter"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Brukernavn eller passord passer ikke til brukeren."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/nl/LC_MESSAGES/django.po
+++ b/taiga/locale/nl/LC_MESSAGES/django.po
@@ -4591,7 +4591,7 @@ msgid "permissions"
 msgstr "toestemmingen"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Gebruikersnaam of wachtwoord stemt niet overeen met gebruiker."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/pl/LC_MESSAGES/django.po
+++ b/taiga/locale/pl/LC_MESSAGES/django.po
@@ -4658,7 +4658,7 @@ msgid "permissions"
 msgstr "uprawnienia"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Nazwa użytkownika lub hasło są nieprawidłowe"
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/pt_BR/LC_MESSAGES/django.po
+++ b/taiga/locale/pt_BR/LC_MESSAGES/django.po
@@ -4758,7 +4758,7 @@ msgid "permissions"
 msgstr "permissões"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Usuário ou senha não correspondem ao usuário"
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/ru/LC_MESSAGES/django.po
+++ b/taiga/locale/ru/LC_MESSAGES/django.po
@@ -5353,7 +5353,7 @@ msgid "permissions"
 msgstr "разрешения"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Имя пользователя или пароль не соответствуют пользователю."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/sr/LC_MESSAGES/django.po
+++ b/taiga/locale/sr/LC_MESSAGES/django.po
@@ -4466,7 +4466,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr ""
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/sv/LC_MESSAGES/django.po
+++ b/taiga/locale/sv/LC_MESSAGES/django.po
@@ -4525,7 +4525,7 @@ msgid "permissions"
 msgstr "behörigheter"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Användarnamn eller lösenord passar inte."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/tr/LC_MESSAGES/django.po
+++ b/taiga/locale/tr/LC_MESSAGES/django.po
@@ -5279,7 +5279,7 @@ msgid "permissions"
 msgstr "izinler"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Kullanıcı adı veya parola kullanıcıyla eşleşmiyor."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/uk/LC_MESSAGES/django.po
+++ b/taiga/locale/uk/LC_MESSAGES/django.po
@@ -4488,7 +4488,7 @@ msgid "permissions"
 msgstr ""
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Ім'я користувача або пароль не відповідають користувачеві."
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/vi/LC_MESSAGES/django.po
+++ b/taiga/locale/vi/LC_MESSAGES/django.po
@@ -4489,7 +4489,7 @@ msgid "permissions"
 msgstr "quyền"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "Tên đăng nhập và mật khẩu không khớp"
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/taiga/locale/zh_Hans/LC_MESSAGES/django.po
@@ -4804,7 +4804,7 @@ msgid "permissions"
 msgstr "权限"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "用户名或密码错误。"
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/taiga/locale/zh_Hant/LC_MESSAGES/django.po
@@ -4578,7 +4578,7 @@ msgid "permissions"
 msgstr "許可"
 
 #: taiga/users/services.py:46 taiga/users/services.py:63
-msgid "Username or password does not matches user."
+msgid "Username or password does not match user."
 msgstr "用戶名稱與密碼不符"
 
 #: taiga/users/templates/emails/change_email-body-html.jinja:12

--- a/taiga/users/services.py
+++ b/taiga/users/services.py
@@ -43,7 +43,7 @@ def get_user_by_username_or_email(username_or_email):
                        Q(email=username_or_email))
 
     if len(qs) == 0:
-        raise exc.WrongArguments(_("Username or password does not matches user."))
+        raise exc.WrongArguments(_("Username or password does not match user."))
 
     user = qs[0]
     return user
@@ -60,7 +60,7 @@ def get_and_validate_user(*, username: str, password: str) -> bool:
 
     user = get_user_by_username_or_email(username)
     if not user.check_password(password) or not user.is_active or user.is_system:
-        raise exc.WrongArguments(_("Username or password does not matches user."))
+        raise exc.WrongArguments(_("Username or password does not match user."))
 
     return user
 


### PR DESCRIPTION
The `WrongArguments` exception class within the `services` module was relaying "Username or password does not matches user." as an error message, which is linguistically incorrect. This PR introduces a fix for the original error message by replacing it with the following content "Username or password does not match user."