### PR TITLE
fix: allow editing a tag's color without triggering already-exists error

### DIFF
--- a/taiga/projects/tagging/validators.py
+++ b/taiga/projects/tagging/validators.py
@@ -59,7 +59,8 @@ class EditTagTagValidator(ProjectTagValidator):
 
     def validate_to_tag(self, attrs, source):
         tag = attrs.get(source, None)
-        if services.tag_exist_for_project_elements(self.project, tag):
+        from_tag = attrs.get("from_tag", None)
+        if tag != from_tag and services.tag_exist_for_project_elements(self.project, tag):
             raise ValidationError(_("This tag already exists."))
 
         return attrs

--- a/tests/integration/test_projects.py
+++ b/tests/integration/test_projects.py
@@ -2019,6 +2019,35 @@ def test_edit_tag_only_color(client, settings):
     assert epic.tags == ["tag"]
 
 
+def test_edit_tag_only_color_with_explicit_to_tag(client, settings):
+    """
+    Regression test for #205: editing only a tag's color should still
+    work even when the client explicitly sends `to_tag` equal to
+    `from_tag` (e.g. a form that always submits the full tag object).
+    """
+    user = f.UserFactory.create()
+    project = f.ProjectFactory.create(owner=user, tags_colors=[("tag", "#123123")])
+    user_story = f.UserStoryFactory.create(project=project, tags=["tag"])
+
+    role = f.RoleFactory.create(project=project, permissions=["view_project"])
+    membership = f.MembershipFactory.create(project=project, user=user, role=role, is_admin=True)
+    url = reverse("projects-edit-tag", args=(project.id,))
+    client.login(user)
+    data = {
+        "from_tag": "tag",
+        "to_tag": "tag",
+        "color": "#AAABBB"
+    }
+
+    client.login(user)
+    response = client.json.post(url, json.dumps(data))
+    assert response.status_code == 200
+    project = Project.objects.get(id=project.pk)
+    assert project.tags_colors == [["tag", "#AAABBB"]]
+    user_story = UserStory.objects.get(id=user_story.pk)
+    assert user_story.tags == ["tag"]
+
+
 def test_edit_tag(client, settings):
     user = f.UserFactory.create()
     project = f.ProjectFactory.create(owner=user, tags_colors=[("tag", "#123123")])


### PR DESCRIPTION
When editing a tag and only changing its color (keeping the same name), a client that explicitly sends to_tag equal to from_tag was incorrectly rejected with 'This tag already exists.', since the uniqueness check didn't account for the case where the tag isn't actually being renamed.

Fixes #205 
Added `test_edit_tag_only_color_with_explicit_to_tag`, which reproduces the bug by sending `to_tag` equal to `from_tag` alongside a new color.
Verified it fails without the fix (400, "This tag already exists.") and passes with it (200). 
Also ran the full `tests/unit/` suite (222 passed) and all `edit_tag` integration tests (4 passed) before and after no regressions.